### PR TITLE
Support SSH GitHub remotes - convert them into normal github URLs

### DIFF
--- a/src/nimib/gits.nim
+++ b/src/nimib/gits.nim
@@ -12,6 +12,8 @@ proc getGitRootDirectory*: AbsoluteDir =
 proc getGitRemoteUrl*: string =
   # https://stackoverflow.com/a/4089452/4178189
   result = execProcess("git", args=["config", "--get", "remote.origin.url"], options={poUsePath}).strip
+  # Convert ssh GitHub origins into https ones
+  result = result.replace("git@github.com:", "https://github.com/")
   result = changeFileExt(result, "")
 
 proc isOnGithub*: bool =

--- a/src/nimib/gits.nim
+++ b/src/nimib/gits.nim
@@ -3,15 +3,15 @@ import std / [os, osproc, strutils]
 import nimib / paths
 
 proc isGitAvailable*: bool =
-  execCmdEx("git --version", options={}).exitcode == 0
+  execCmdEx("git --version", options={poUsePath}).exitcode == 0
 
 proc getGitRootDirectory*: AbsoluteDir =
   # https://stackoverflow.com/a/957978/4178189
-  execProcess("git", args=["rev-parse", "--show-toplevel"], options={}).strip.AbsoluteDir
+  execProcess("git", args=["rev-parse", "--show-toplevel"], options={poUsePath}).strip.AbsoluteDir
 
 proc getGitRemoteUrl*: string =
   # https://stackoverflow.com/a/4089452/4178189
-  result = execProcess("git", args=["config", "--get", "remote.origin.url"], options={}).strip
+  result = execProcess("git", args=["config", "--get", "remote.origin.url"], options={poUsePath}).strip
   result = changeFileExt(result, "")
 
 proc isOnGithub*: bool =


### PR DESCRIPTION
This is based on https://github.com/pietroppeter/nimib/pull/21 so merge it first :)

A "default" GitHub SSH remote looks like this: `git@github.com:Yardanico/nimib.git`

Right now I only decided to support the "default" GitHub SSH remotes (the ones that it gives when creating a new repo or checking out an existing one) without the `ssh://` prefix.
