### PR TITLE
Update mostaccio as man AND escape by default all code output

### DIFF
--- a/docs/mostaccio.html
+++ b/docs/mostaccio.html
@@ -160,6 +160,13 @@ context[<span class="hljs-string">&quot;repo&quot;</span>] = %*[{<span class="hl
 <pre><samp>&lt;b&gt;resque&lt;/b&gt;
   &lt;b&gt;hub&lt;/b&gt;
   &lt;b&gt;rip&lt;/b&gt;</samp></pre>
+<blockquote>
+<p>output is not the expected output:</p>
+</blockquote>
+<pre><code>&lt;b&gt;resque&lt;/b&gt;
+&lt;b&gt;hub&lt;/b&gt;
+&lt;b&gt;rip&lt;/b&gt;
+</code></pre>
 <h4>Lambdas</h4>
 <p>When the value is a callable object, such as a function or lambda, the object will be invoked and passed the block of text.
 The text passed is the literal block, unrendered.
@@ -177,6 +184,11 @@ context[<span class="hljs-string">&quot;wrapped&quot;</span>] = <span class="hlj
 <pre><code class="nim hljs"><span class="hljs-keyword">echo</span> tmpl.render(context)</code></pre>
 <pre><samp>&lt;b&gt;  Willy is awesome.
 &lt;/b&gt;</samp></pre>
+<blockquote>
+<p>output is not the expected output:</p>
+</blockquote>
+<pre><code>&lt;b&gt;Willy is awesome.&lt;/b&gt;
+</code></pre>
 <h4>Non-False Values</h4>
 <p>When the value is non-false but not a list,
 it will be used as the context for a single rendering of the block.</p>
@@ -216,6 +228,83 @@ context[<span class="hljs-string">&quot;repo&quot;</span>] = empty</code></pre>
 <p>Will render as follows:</p>
 <pre><code class="nim hljs"><span class="hljs-keyword">echo</span> tmpl.render(newContext())</code></pre>
 <pre><samp>&lt;h1&gt;Today.&lt;/h1&gt;</samp></pre>
+<h3>Partials</h3>
+<p>Partials begin with a greater than sign, like <code>{{&gt; box}}</code>.</p>
+<p>Partials are rendered at runtime (as opposed to compile time),
+so recursive partials are possible. Just avoid infinite loops.</p>
+<p>They also inherit the calling context.
+Whereas in an <a href="http://en.wikipedia.org/wiki/ERuby">ERB</a> file you may have this:</p>
+<pre><code>&lt;%= partial :next_more, :start =&gt; start, :size =&gt; size %&gt;
+</code></pre>
+<p>Mustache requires only this:</p>
+<pre><code>{{&gt; next_more}}
+</code></pre>
+<p>Why? Because the <code>next_more.mustache</code> file will inherit
+the size and start methods from the calling context.</p>
+<p>In this way you may want to think of partials as
+includes, imports, template expansion, nested templates,
+or subtemplates, even though those aren't literally the case here.</p>
+<p>For example, this template and partial:</p>
+<pre><code class="nim hljs"><span class="hljs-keyword">let</span> base = <span class="hljs-string">&quot;&quot;&quot;&lt;h2&gt;Names&lt;/h2&gt;
+{{#names}}
+  {{&gt; user}}
+{{/names}}
+&quot;&quot;&quot;</span>
+<span class="hljs-keyword">let</span> user = <span class="hljs-string">&quot;&lt;strong&gt;{{name}}&lt;/strong&gt;</span><span class="hljs-meta">\n</span><span class="hljs-string">&quot;</span></code></pre>
+<p>Can be thought of as a single, expanded template:</p>
+<pre><code class="nim hljs"><span class="hljs-keyword">let</span> expanded = <span class="hljs-string">&quot;&quot;&quot;&lt;h2&gt;Names&lt;/h2&gt;
+{{#names}}
+  &lt;strong&gt;{{name}}&lt;/strong&gt;
+{{/names}}
+&quot;&quot;&quot;</span></code></pre>
+<blockquote>
+<p><code>nim-mustache</code> allows to use partials in-memory.
+By default nim-mustache looks for <code>.mustache</code> files in current directory
+but the behaviour of where to find partials (which directories or in-memory)
+can be fully customized
+(see <a href="https://github.com/soasme/nim-mustache#read-partials-from-memory">here</a>).</p>
+<p>Below we show an example where we only search in-memory.</p>
+</blockquote>
+<pre><code class="nim hljs"><span class="hljs-keyword">import</span>
+  tables
+
+<span class="hljs-keyword">let</span> partials = {<span class="hljs-string">&quot;base&quot;</span>: base, <span class="hljs-string">&quot;user&quot;</span>: user, <span class="hljs-string">&quot;expanded&quot;</span>: expanded}.toTable
+context = newContext(searchDirs = @[], partials = partials)
+context[<span class="hljs-string">&quot;names&quot;</span>] = %*[{<span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;resque&quot;</span>}, {<span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;hub&quot;</span>}, {<span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;rip&quot;</span>}]
+<span class="hljs-keyword">echo</span> <span class="hljs-string">&quot;{{&gt;base}}&quot;</span>.render(context)</code></pre>
+<pre><samp>&lt;h2&gt;Names&lt;/h2&gt;
+  &lt;strong&gt;resque&lt;/strong&gt;
+  &lt;strong&gt;hub&lt;/strong&gt;
+  &lt;strong&gt;rip&lt;/strong&gt;</samp></pre>
+<pre><code class="nim hljs"><span class="hljs-keyword">echo</span> <span class="hljs-string">&quot;{{&gt;expanded}}&quot;</span>.render(context)</code></pre>
+<pre><samp>&lt;h2&gt;Names&lt;/h2&gt;
+  &lt;strong&gt;resque&lt;/strong&gt;
+  &lt;strong&gt;hub&lt;/strong&gt;
+  &lt;strong&gt;rip&lt;/strong&gt;</samp></pre>
+<h3>Set Delimiter</h3>
+<p>Set Delimiter tags start with an equal sign and change the tag delimiters from {{ and }} to custom strings.</p>
+<p>Consider the following contrived example:</p>
+<pre><code class="nim hljs">tmpl = <span class="hljs-string">&quot;&quot;&quot;* {{default_tags}}
+{{=&lt;% %&gt;=}}
+* &lt;% erb_style_tags %&gt;
+&lt;%={{ }}=%&gt;
+* {{ default_tags_again }}
+&quot;&quot;&quot;</span></code></pre>
+<p>Here we have a list with three items. The first item uses the default tag style, the second uses erb style as defined by the Set Delimiter tag, and the third returns to the default style after yet another Set Delimiter declaration.</p>
+<p>According to ctemplates, this &quot;is useful for languages like TeX,
+where double-braces may occur in the text and are awkward to use for markup.&quot;</p>
+<p>Custom delimiters may not contain whitespace or the equals sign.</p>
+<blockquote>
+<p>adding an example of usage of set delimiter feature</p>
+</blockquote>
+<pre><code class="nim hljs">context = newContext()
+context[<span class="hljs-string">&quot;default_tags&quot;</span>] = <span class="hljs-string">&quot;one&quot;</span>
+context[<span class="hljs-string">&quot;erb_style_tags&quot;</span>] = <span class="hljs-string">&quot;two&quot;</span>
+context[<span class="hljs-string">&quot;default_tags_again&quot;</span>] = <span class="hljs-string">&quot;three&quot;</span>
+<span class="hljs-keyword">echo</span> tmpl.render(context)</code></pre>
+<pre><samp>* one
+* two
+* three</samp></pre>
 
 </main>
 <footer>
@@ -388,6 +477,15 @@ nbCode:
 nbText: <span class="hljs-string">&quot;Output:&quot;</span>
 nbCode:
   <span class="hljs-keyword">echo</span> tmpl.render(context)
+nbText: <span class="hljs-string">&quot;&quot;&quot;&gt; output is not the expected output:
+
+```
+&lt;b&gt;resque&lt;/b&gt;
+&lt;b&gt;hub&lt;/b&gt;
+&lt;b&gt;rip&lt;/b&gt;
+```
+&quot;&quot;&quot;</span>
+
 nbText: <span class="hljs-string">&quot;&quot;&quot;
 #### Lambdas
 
@@ -410,6 +508,13 @@ nbCode:
 nbText: <span class="hljs-string">&quot;Output:&quot;</span>
 nbCode:
   <span class="hljs-keyword">echo</span> tmpl.render(context)
+nbText: <span class="hljs-string">&quot;&quot;&quot;&gt; output is not the expected output:
+
+```
+&lt;b&gt;Willy is awesome.&lt;/b&gt;
+```
+&quot;&quot;&quot;</span>
+
 nbText: <span class="hljs-string">&quot;&quot;&quot;
 #### Non-False Values
 
@@ -468,9 +573,112 @@ nbCode:
 nbText: <span class="hljs-string">&quot;Will render as follows:&quot;</span>
 nbCode:
   <span class="hljs-keyword">echo</span> tmpl.render(newContext())
+nbText: <span class="hljs-string">&quot;&quot;&quot;
+### Partials
 
-<span class="hljs-comment">### Partials</span>
-<span class="hljs-comment">### Set Delimiter</span>
+Partials begin with a greater than sign, like `{{&gt; box}}`.
+
+Partials are rendered at runtime (as opposed to compile time),
+so recursive partials are possible. Just avoid infinite loops.
+
+They also inherit the calling context.
+Whereas in an [ERB](http://en.wikipedia.org/wiki/ERuby) file you may have this:
+
+```
+&lt;%= partial :next_more, :start =&gt; start, :size =&gt; size %&gt;
+```
+
+Mustache requires only this:
+
+```
+{{&gt; next_more}}
+```
+
+Why? Because the `next_more.mustache` file will inherit
+the size and start methods from the calling context.
+
+In this way you may want to think of partials as
+includes, imports, template expansion, nested templates,
+or subtemplates, even though those aren't literally the case here.
+
+For example, this template and partial:
+&quot;&quot;&quot;</span>
+nbCode:
+  <span class="hljs-keyword">let</span> base = <span class="hljs-string">&quot;&quot;&quot;
+&lt;h2&gt;Names&lt;/h2&gt;
+{{#names}}
+  {{&gt; user}}
+{{/names}}
+&quot;&quot;&quot;</span>
+  <span class="hljs-keyword">let</span> user = <span class="hljs-string">&quot;&lt;strong&gt;{{name}}&lt;/strong&gt;</span><span class="hljs-meta">\n</span><span class="hljs-string">&quot;</span>
+nbText: <span class="hljs-string">&quot;Can be thought of as a single, expanded template:&quot;</span>
+nbCode:
+  <span class="hljs-keyword">let</span> expanded = <span class="hljs-string">&quot;&quot;&quot;
+&lt;h2&gt;Names&lt;/h2&gt;
+{{#names}}
+  &lt;strong&gt;{{name}}&lt;/strong&gt;
+{{/names}}
+&quot;&quot;&quot;</span>
+nbText: <span class="hljs-string">&quot;&quot;&quot;
+&gt; `nim-mustache` allows to use partials in-memory.
+&gt; By default nim-mustache looks for `.mustache` files in current directory
+&gt; but the behaviour of where to find partials (which directories or in-memory)
+&gt; can be fully customized
+&gt; (see [here](https://github.com/soasme/nim-mustache#read-partials-from-memory)).
+&gt;
+&gt; Below we show an example where we only search in-memory.
+&quot;&quot;&quot;</span>
+nbCode:
+  <span class="hljs-keyword">import</span> tables
+  <span class="hljs-keyword">let</span> partials = {
+    <span class="hljs-string">&quot;base&quot;</span>: base,
+    <span class="hljs-string">&quot;user&quot;</span>: user,
+    <span class="hljs-string">&quot;expanded&quot;</span>: expanded
+  }.toTable
+  
+  context = newContext(searchDirs = @[], partials=partials)
+  context[<span class="hljs-string">&quot;names&quot;</span>] = %* [
+    { <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;resque&quot;</span> },
+    { <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;hub&quot;</span> },
+    { <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;rip&quot;</span> }
+  ]
+
+  <span class="hljs-keyword">echo</span> <span class="hljs-string">&quot;{{&gt;base}}&quot;</span>.render(context)
+nbCode:
+  <span class="hljs-keyword">echo</span> <span class="hljs-string">&quot;{{&gt;expanded}}&quot;</span>.render(context)
+nbText: <span class="hljs-string">&quot;&quot;&quot;
+### Set Delimiter
+
+Set Delimiter tags start with an equal sign and change the tag delimiters from {{ and }} to custom strings.
+
+Consider the following contrived example:
+
+&quot;&quot;&quot;</span>
+nbCode:
+  tmpl = <span class="hljs-string">&quot;&quot;&quot;
+* {{default_tags}}
+{{=&lt;% %&gt;=}}
+* &lt;% erb_style_tags %&gt;
+&lt;%={{ }}=%&gt;
+* {{ default_tags_again }}
+&quot;&quot;&quot;</span>
+nbText: <span class="hljs-string">&quot;&quot;&quot;
+Here we have a list with three items. The first item uses the default tag style, the second uses erb style as defined by the Set Delimiter tag, and the third returns to the default style after yet another Set Delimiter declaration.
+
+According to ctemplates, this &quot;is useful for languages like TeX,
+where double-braces may occur in the text and are awkward to use for markup.&quot;
+
+Custom delimiters may not contain whitespace or the equals sign.
+
+&gt; adding an example of usage of set delimiter feature
+&quot;&quot;&quot;</span> <span class="hljs-comment"># probably also useful for delayed rendering</span>
+nbCode:
+  context = newContext()
+  context[<span class="hljs-string">&quot;default_tags&quot;</span>] = <span class="hljs-string">&quot;one&quot;</span>
+  context[<span class="hljs-string">&quot;erb_style_tags&quot;</span>] = <span class="hljs-string">&quot;two&quot;</span>
+  context[<span class="hljs-string">&quot;default_tags_again&quot;</span>] = <span class="hljs-string">&quot;three&quot;</span>
+  <span class="hljs-keyword">echo</span> tmpl.render(context)
+
 <span class="hljs-comment">## COPYRIGHT</span>
 <span class="hljs-comment">## SEE ALSO</span>
 nbShow

--- a/docs/mostaccio.html
+++ b/docs/mostaccio.html
@@ -681,7 +681,7 @@ nbCode:
 
 <span class="hljs-comment">## COPYRIGHT</span>
 <span class="hljs-comment">## SEE ALSO</span>
-nbShow
+nbSave
 <span class="hljs-comment"># idea: document that shows all spec tests of nim mustache (do this in nblog)</span></code></pre>
 </section><script>
 function toggleSourceDisplay() {

--- a/docs/mostaccio.html
+++ b/docs/mostaccio.html
@@ -122,6 +122,100 @@ context[<span class="hljs-string">&quot;company&quot;</span>] = <span class="hlj
 <p>added the <code>{{&amp;company}}</code> to clarify that it is just an alternative syntax with the same result
 as the triple mustache.</p>
 </blockquote>
+<h3>Sections</h3>
+<p>Sections render blocks of text one or more times, depending on the value of the key in the current context.</p>
+<p>A section begins with a pound and ends with a slash.
+That is, <code>{{#person}}</code> begins a &quot;person&quot; section while <code>{{/person}}</code> ends it.</p>
+<p>The behavior of the section is determined by the value of the key.</p>
+<h4>False Values or Empty Lists</h4>
+<p>If the person key exists and has a value of false or an empty list, the HTML between the pound and slash will not be displayed.</p>
+<p>Template:</p>
+<pre><code class="nim hljs">tmpl = <span class="hljs-string">&quot;&quot;&quot;Shown.
+{{#person}}
+  Never shown!
+{{/person}}&quot;&quot;&quot;</span></code></pre>
+<p>Context:</p>
+<pre><code class="nim hljs">context = newContext()
+context[<span class="hljs-string">&quot;person&quot;</span>] = <span class="hljs-literal">false</span></code></pre>
+<p>Output:</p>
+<pre><code class="nim hljs"><span class="hljs-keyword">echo</span> tmpl.render(context)</code></pre>
+<pre><samp>Shown.</samp></pre>
+<h4>Non-Empty Lists</h4>
+<p>If the <strong>person</strong> key exists and has a non-false value,
+the HTML between the pound and slash will be rendered and displayed one or more times.</p>
+<p>When the value is a non-empty list, the text in the block will be displayed once for each item in the list.
+The context of the block will be set to the current item for each iteration. In this way we can loop over collections.</p>
+<p>Template:</p>
+<pre><code class="nim hljs">tmpl = <span class="hljs-string">&quot;&quot;&quot;{{#repo}}
+  &lt;b&gt;{{name}}&lt;/b&gt;
+{{/repo}}&quot;&quot;&quot;</span></code></pre>
+<p>Context:</p>
+<pre><code class="nim hljs"><span class="hljs-keyword">import</span>
+  json
+
+context = newContext()
+context[<span class="hljs-string">&quot;repo&quot;</span>] = %*[{<span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;resque&quot;</span>}, {<span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;hub&quot;</span>}, {<span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;rip&quot;</span>}]</code></pre>
+<p>Output:</p>
+<pre><code class="nim hljs"><span class="hljs-keyword">echo</span> tmpl.render(context)</code></pre>
+<pre><samp>&lt;b&gt;resque&lt;/b&gt;
+  &lt;b&gt;hub&lt;/b&gt;
+  &lt;b&gt;rip&lt;/b&gt;</samp></pre>
+<h4>Lambdas</h4>
+<p>When the value is a callable object, such as a function or lambda, the object will be invoked and passed the block of text.
+The text passed is the literal block, unrendered.
+<code>{{tags}}</code> will not have been expanded - the lambda should do that on its own. In this way you can implement filters or caching.</p>
+<p>Template:</p>
+<pre><code class="nim hljs">tmpl = <span class="hljs-string">&quot;&quot;&quot;{{#wrapped}}
+  {{name}} is awesome.
+{{/wrapped}}&quot;&quot;&quot;</span></code></pre>
+<p>Context:</p>
+<pre><code class="nim hljs">context = newContext()
+context[<span class="hljs-string">&quot;name&quot;</span>] = <span class="hljs-string">&quot;Willy&quot;</span>
+context[<span class="hljs-string">&quot;wrapped&quot;</span>] = <span class="hljs-keyword">proc</span> (s: <span class="hljs-built_in">string</span>; c: <span class="hljs-type">Context</span>): <span class="hljs-built_in">string</span> =
+  <span class="hljs-string">&quot;&lt;b&gt;&quot;</span> &amp; s.render(c) &amp; <span class="hljs-string">&quot;&lt;/b&gt;&quot;</span></code></pre>
+<p>Output:</p>
+<pre><code class="nim hljs"><span class="hljs-keyword">echo</span> tmpl.render(context)</code></pre>
+<pre><samp>&lt;b&gt;  Willy is awesome.
+&lt;/b&gt;</samp></pre>
+<h4>Non-False Values</h4>
+<p>When the value is non-false but not a list,
+it will be used as the context for a single rendering of the block.</p>
+<p>Template:</p>
+<pre><code class="nim hljs">tmpl = <span class="hljs-string">&quot;&quot;&quot;{{#person?}}
+  Hi {{name}}!
+{{/person?}}&quot;&quot;&quot;</span></code></pre>
+<p>Context:</p>
+<pre><code class="nim hljs">context = newContext()
+context[<span class="hljs-string">&quot;person?&quot;</span>] = %*{<span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;Jon&quot;</span>}</code></pre>
+<p>Output:</p>
+<pre><code class="nim hljs"><span class="hljs-keyword">echo</span> tmpl.render(context)</code></pre>
+<pre><samp>Hi Jon!</samp></pre>
+<h3>Inverted Sections</h3>
+<p>An inverted section begins with a caret (hat) and ends with a slash.
+That is <code>{{^person}}</code> begins a &quot;person&quot; inverted section while <code>{{/person}}</code> ends it.</p>
+<p>While sections can be used to render text one or more times based on the value of the key,
+inverted sections may render text once based on the inverse value of the key.
+That is, they will be rendered if the key doesn't exist, is false, or is an empty list.</p>
+<p>Template:</p>
+<pre><code class="nim hljs">tmpl = <span class="hljs-string">&quot;&quot;&quot;{{#repo}}
+  &lt;b&gt;{{name}}&lt;/b&gt;
+{{/repo}}
+{{^repo}}
+  No repos :(
+{{/repo}}&quot;&quot;&quot;</span></code></pre>
+<p>Context:</p>
+<pre><code class="nim hljs">context = newContext()
+<span class="hljs-keyword">let</span> empty: <span class="hljs-built_in">seq</span>[<span class="hljs-built_in">string</span>] = @[]
+context[<span class="hljs-string">&quot;repo&quot;</span>] = empty</code></pre>
+<p>Output:</p>
+<pre><code class="nim hljs"><span class="hljs-keyword">echo</span> tmpl.render(context)</code></pre>
+<pre><samp>No repos :(</samp></pre>
+<h3>Comments</h3>
+<p>Comments begin with a bang and are ignored. The following template:</p>
+<pre><code class="nim hljs">tmpl = <span class="hljs-string">&quot;&quot;&quot;&lt;h1&gt;Today{{! ignore me }}.&lt;/h1&gt;&quot;&quot;&quot;</span></code></pre>
+<p>Will render as follows:</p>
+<pre><code class="nim hljs"><span class="hljs-keyword">echo</span> tmpl.render(newContext())</code></pre>
+<pre><samp>&lt;h1&gt;Today.&lt;/h1&gt;</samp></pre>
 
 </main>
 <footer>
@@ -219,7 +313,8 @@ The Ruby version of Mustache supports raising an exception in this situation, fo
 Template:
 &quot;&quot;&quot;</span> <span class="hljs-comment"># is there a way to raise the exception in nim-mustache?</span>
 nbCode:
-  tmpl = <span class="hljs-string">&quot;&quot;&quot;* {{name}}
+  tmpl = <span class="hljs-string">&quot;&quot;&quot;
+* {{name}}
 * {{age}}
 * {{company}}
 * {{{company}}}
@@ -231,22 +326,155 @@ nbCode:
   context[<span class="hljs-string">&quot;company&quot;</span>] = <span class="hljs-string">&quot;&lt;b&gt;Github&lt;/b&gt;&quot;</span>
 nbText: <span class="hljs-string">&quot;Output:&quot;</span>
 nbCode:
-  <span class="hljs-keyword">echo</span> tmpl.render(context) <span class="hljs-comment"># the output is not correctly escaped!!! BIG TODO!</span>
+  <span class="hljs-keyword">echo</span> tmpl.render(context)
 nbText: <span class="hljs-string">&quot;&quot;&quot;
 &gt; added the `{{&amp;company}}` to clarify that it is just an alternative syntax with the same result
 &gt; as the triple mustache.
+
+### Sections
+
+Sections render blocks of text one or more times, depending on the value of the key in the current context.
+
+A section begins with a pound and ends with a slash.
+That is, `{{#person}}` begins a &quot;person&quot; section while `{{/person}}` ends it.
+
+The behavior of the section is determined by the value of the key.
+
+#### False Values or Empty Lists
+
+If the person key exists and has a value of false or an empty list, the HTML between the pound and slash will not be displayed.
+
+Template:
 &quot;&quot;&quot;</span>
-<span class="hljs-comment">### Sections</span>
-<span class="hljs-comment">#### Non-Empty Lists</span>
-<span class="hljs-comment">#### Lambdas</span>
-<span class="hljs-comment">#### Non-False Values</span>
-<span class="hljs-comment">### Inverted Sections</span>
-<span class="hljs-comment">### Comments</span>
+nbCode:
+  tmpl = <span class="hljs-string">&quot;&quot;&quot;
+Shown.
+{{#person}}
+  Never shown!
+{{/person}}&quot;&quot;&quot;</span>
+nbText: <span class="hljs-string">&quot;Context:&quot;</span>
+nbCode:
+  context = newContext()
+  context[<span class="hljs-string">&quot;person&quot;</span>] = <span class="hljs-literal">false</span>
+nbText: <span class="hljs-string">&quot;Output:&quot;</span>
+nbCode:
+  <span class="hljs-keyword">echo</span> tmpl.render(context)
+nbText: <span class="hljs-string">&quot;&quot;&quot;
+#### Non-Empty Lists
+
+If the **person** key exists and has a non-false value,
+the HTML between the pound and slash will be rendered and displayed one or more times.
+
+When the value is a non-empty list, the text in the block will be displayed once for each item in the list.
+The context of the block will be set to the current item for each iteration. In this way we can loop over collections.
+
+Template:
+&quot;&quot;&quot;</span>
+nbCode:
+  tmpl = <span class="hljs-string">&quot;&quot;&quot;
+{{#repo}}
+  &lt;b&gt;{{name}}&lt;/b&gt;
+{{/repo}}&quot;&quot;&quot;</span>
+nbText: <span class="hljs-string">&quot;Context:&quot;</span>
+nbCode:
+  <span class="hljs-keyword">import</span> json
+  context = newContext()
+  context[<span class="hljs-string">&quot;repo&quot;</span>] = %* [
+    { <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;resque&quot;</span> },
+    { <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;hub&quot;</span> },
+    { <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;rip&quot;</span> }
+  ]
+<span class="hljs-comment"># add a note to explain better what is Context and what can be casted to a context value?</span>
+nbText: <span class="hljs-string">&quot;Output:&quot;</span>
+nbCode:
+  <span class="hljs-keyword">echo</span> tmpl.render(context)
+nbText: <span class="hljs-string">&quot;&quot;&quot;
+#### Lambdas
+
+When the value is a callable object, such as a function or lambda, the object will be invoked and passed the block of text.
+The text passed is the literal block, unrendered.
+`{{tags}}` will not have been expanded - the lambda should do that on its own. In this way you can implement filters or caching.
+
+Template:
+&quot;&quot;&quot;</span>
+nbCode:
+  tmpl = <span class="hljs-string">&quot;&quot;&quot;
+{{#wrapped}}
+  {{name}} is awesome.
+{{/wrapped}}&quot;&quot;&quot;</span>
+nbText: <span class="hljs-string">&quot;Context:&quot;</span>
+nbCode:
+  context = newContext()
+  context[<span class="hljs-string">&quot;name&quot;</span>] = <span class="hljs-string">&quot;Willy&quot;</span>
+  context[<span class="hljs-string">&quot;wrapped&quot;</span>] = <span class="hljs-keyword">proc</span>(s: <span class="hljs-built_in">string</span>, c: <span class="hljs-type">Context</span>): <span class="hljs-built_in">string</span> = <span class="hljs-string">&quot;&lt;b&gt;&quot;</span> &amp; s.render(c) &amp; <span class="hljs-string">&quot;&lt;/b&gt;&quot;</span>
+nbText: <span class="hljs-string">&quot;Output:&quot;</span>
+nbCode:
+  <span class="hljs-keyword">echo</span> tmpl.render(context)
+nbText: <span class="hljs-string">&quot;&quot;&quot;
+#### Non-False Values
+
+When the value is non-false but not a list,
+it will be used as the context for a single rendering of the block.
+
+Template:
+&quot;&quot;&quot;</span>
+nbCode:
+  tmpl = <span class="hljs-string">&quot;&quot;&quot;
+{{#person?}}
+  Hi {{name}}!
+{{/person?}}&quot;&quot;&quot;</span>
+nbText: <span class="hljs-string">&quot;Context:&quot;</span>
+nbCode:
+  context = newContext()
+  context[<span class="hljs-string">&quot;person?&quot;</span>] = %* { <span class="hljs-string">&quot;name&quot;</span>: <span class="hljs-string">&quot;Jon&quot;</span> }
+nbText: <span class="hljs-string">&quot;Output:&quot;</span>
+nbCode:
+  <span class="hljs-keyword">echo</span> tmpl.render(context)
+nbText: <span class="hljs-string">&quot;&quot;&quot;
+### Inverted Sections
+
+An inverted section begins with a caret (hat) and ends with a slash.
+That is `{{^person}}` begins a &quot;person&quot; inverted section while `{{/person}}` ends it.
+
+While sections can be used to render text one or more times based on the value of the key,
+inverted sections may render text once based on the inverse value of the key.
+That is, they will be rendered if the key doesn't exist, is false, or is an empty list.
+
+Template:
+&quot;&quot;&quot;</span>
+nbCode:
+  tmpl = <span class="hljs-string">&quot;&quot;&quot;
+{{#repo}}
+  &lt;b&gt;{{name}}&lt;/b&gt;
+{{/repo}}
+{{^repo}}
+  No repos :(
+{{/repo}}&quot;&quot;&quot;</span>
+nbText: <span class="hljs-string">&quot;Context:&quot;</span>
+nbCode:
+  context = newContext()
+  <span class="hljs-keyword">let</span> empty: <span class="hljs-built_in">seq</span>[<span class="hljs-built_in">string</span>] = @[]
+  context[<span class="hljs-string">&quot;repo&quot;</span>] = empty  <span class="hljs-comment"># does not work with seq or array or also with %* []</span>
+nbText: <span class="hljs-string">&quot;Output:&quot;</span>
+nbCode:
+  <span class="hljs-keyword">echo</span> tmpl.render(context)
+nbText: <span class="hljs-string">&quot;&quot;&quot;
+### Comments
+
+Comments begin with a bang and are ignored. The following template:
+&quot;&quot;&quot;</span>
+nbCode:
+  tmpl = <span class="hljs-string">&quot;&quot;&quot;&lt;h1&gt;Today{{! ignore me }}.&lt;/h1&gt;&quot;&quot;&quot;</span>
+nbText: <span class="hljs-string">&quot;Will render as follows:&quot;</span>
+nbCode:
+  <span class="hljs-keyword">echo</span> tmpl.render(newContext())
+
 <span class="hljs-comment">### Partials</span>
 <span class="hljs-comment">### Set Delimiter</span>
 <span class="hljs-comment">## COPYRIGHT</span>
 <span class="hljs-comment">## SEE ALSO</span>
-nbShow</code></pre>
+nbShow
+<span class="hljs-comment"># idea: document that shows all spec tests of nim mustache (do this in nblog)</span></code></pre>
 </section><script>
 function toggleSourceDisplay() {
   var btn = document.getElementById("show")

--- a/docs/mostaccio.html
+++ b/docs/mostaccio.html
@@ -39,43 +39,89 @@ section#source {
 </div>
 <hr>
 </header><main>
-<h1>Example of usage of mustache</h1>
-<p>From <a href="https://github.com/soasme/nim-mustache">nim-mustache</a>.</p>
-<h2>Usage</h2>
-<p>Step 1.</p>
+<h1>mustache man (5)</h1>
+<p><a href="https://mustache.github.io/">mustache</a> is a logic-less template system
+with implementations available in multiple languages.</p>
+<p>In nim there are two implementations:</p>
+<ul>
+<li><a href="https://github.com/soasme/nim-mustache">nim-mustache</a></li>
+<li><a href="https://github.com/fenekku/moustachu">moustachu</a></li>
+</ul>
+<p><a href="https://pietroppeter.github.io/nimib/">nimib</a> uses <code>nim-mustache</code> and takes
+specific advantage of its feature for in-memory partials to store default templates.</p>
+<p>Below I will show examples of usage of <code>mustache</code> using <code>nim-mustache</code>,
+mostly replicating <a href="https://mustache.github.io/mustache.5.html">mustache(5)</a> man page
+(<a href="https://en.wikipedia.org/wiki/Man_page#Manual_sections">why (5)?</a>).</p>
 <pre><code class="nim hljs"><span class="hljs-keyword">import</span>
-  mustache, tables</code></pre>
-<p>Step 2.</p>
-<pre><code class="nim hljs"><span class="hljs-keyword">var</span> c = newContext()
-c[<span class="hljs-string">&quot;i&quot;</span>] = <span class="hljs-number">1</span>
-c[<span class="hljs-string">&quot;f&quot;</span>] = <span class="hljs-number">1.0</span>
-c[<span class="hljs-string">&quot;s&quot;</span>] = <span class="hljs-string">&quot;hello world&quot;</span>
-c[<span class="hljs-string">&quot;a&quot;</span>] = @[{<span class="hljs-string">&quot;k&quot;</span>: <span class="hljs-string">&quot;v&quot;</span>}.toTable]
-c[<span class="hljs-string">&quot;t&quot;</span>] = {<span class="hljs-string">&quot;k&quot;</span>: <span class="hljs-string">&quot;v&quot;</span>}.toTable
-c[<span class="hljs-string">&quot;l&quot;</span>] = <span class="hljs-keyword">proc</span> (s: <span class="hljs-built_in">string</span>; c: <span class="hljs-type">Context</span>): <span class="hljs-built_in">string</span> =
-  <span class="hljs-string">&quot;&amp;lt;b&amp;gt;&quot;</span> &amp; s.render(c) &amp; <span class="hljs-string">&quot;&amp;lt;/b&amp;gt;&quot;</span></code></pre>
-<p>Step 3.</p>
-<pre><code class="nim hljs"><span class="hljs-keyword">let</span> s = <span class="hljs-string">&quot;&quot;&quot;{{i}} {{f}} {{s}}
-{{#a}}
-  {{k}}
-{{/a}}
-
-{{#t}}
-  {{k}}
-{{/t}}
-
-{{#l}}
-  {{s}}
-{{/l}}
-&quot;&quot;&quot;</span>
-<span class="hljs-keyword">echo</span>(s.render(c))</code></pre>
-<pre><samp>1 1.0 hello world
-  v
-
-  v
-
-<b>  hello world
-</b></samp></pre>
+  mustache</code></pre>
+<h2>SYNOPSIS</h2>
+<p>A typical mustache template:</p>
+<pre><code class="nim hljs"><span class="hljs-keyword">var</span> tmpl = <span class="hljs-string">&quot;&quot;&quot;Hello {{name}}
+You have just won {{value}} dollars!
+{{#in_california}}
+Well, {{taxed_value}} dollars, after taxes.
+{{/in_california}}
+&quot;&quot;&quot;</span></code></pre>
+<p>Given the following context:</p>
+<pre><code class="nim hljs"><span class="hljs-keyword">var</span> context = newContext()
+context[<span class="hljs-string">&quot;name&quot;</span>] = <span class="hljs-string">&quot;Chris&quot;</span>
+context[<span class="hljs-string">&quot;value&quot;</span>] = <span class="hljs-number">10000</span>
+context[<span class="hljs-string">&quot;taxed_value&quot;</span>] = <span class="hljs-number">10000</span> - (<span class="hljs-number">10000</span> * <span class="hljs-number">0.4</span>)
+context[<span class="hljs-string">&quot;in_california&quot;</span>] = <span class="hljs-literal">true</span></code></pre>
+<p>Will produce the following:</p>
+<pre><code class="nim hljs"><span class="hljs-keyword">echo</span> tmpl.render(context)</code></pre>
+<pre><samp>Hello Chris
+You have just won 10000 dollars!
+Well, 6000.0 dollars, after taxes.</samp></pre>
+<h2>DESCRIPTION</h2>
+<p>Mustache can be used for HTML, config files, source code - anything.
+It works by expanding tags in a template using values provided in a context
+object.</p>
+<p>We call it &quot;logic-less&quot; because there are no if statements, else clauses, or for loops.
+Instead there are only tags.
+Some tags are replaced with a value, some nothing, and others a series of values.
+This document explains the different types of Mustache tags.</p>
+<blockquote>
+<p>in this document we use the <code>context</code> keyword instead of referring to it as a hash or object
+as in the original document</p>
+</blockquote>
+<h2>TAG TYPES</h2>
+<p>Tags are indicated by the double mustaches. <code>{{person}}</code> is a <strong>tag</strong>, as is <code>{{#person}}</code>.
+In both examples, we'd refer to person as the key or tag key.
+Let's talk about the different types of tags.</p>
+<h3>Variables</h3>
+<p>The most basic tag type is the variable.
+A <code>{{name}}</code> tag in a basic template will try to find the <strong>name</strong> key in the current context.
+If there is no <strong>name</strong> key, the parent contexts will be checked recursively.
+If the top context is reached and the <strong>name</strong> key is still not found, nothing will be rendered.</p>
+<p>All variables are HTML escaped by default.
+If you want to return unescaped HTML, use the triple mustache: <code>{{{name}}}</code>.</p>
+<p>You can also use &amp; to unescape a variable: <code>{{&amp; name}}</code>.
+This may be useful when changing delimiters (see &quot;Set Delimiter&quot; below).</p>
+<p>By default a variable &quot;miss&quot; returns an empty string.
+This can usually be configured in your Mustache library.
+The Ruby version of Mustache supports raising an exception in this situation, for instance.</p>
+<p>Template:</p>
+<pre><code class="nim hljs">tmpl = <span class="hljs-string">&quot;&quot;&quot;* {{name}}
+* {{age}}
+* {{company}}
+* {{{company}}}
+* {{&amp;company}}&quot;&quot;&quot;</span></code></pre>
+<p>Context:</p>
+<pre><code class="nim hljs">context = newContext()
+context[<span class="hljs-string">&quot;name&quot;</span>] = <span class="hljs-string">&quot;Chris&quot;</span>
+context[<span class="hljs-string">&quot;company&quot;</span>] = <span class="hljs-string">&quot;&lt;b&gt;Github&lt;/b&gt;&quot;</span></code></pre>
+<p>Output:</p>
+<pre><code class="nim hljs"><span class="hljs-keyword">echo</span> tmpl.render(context)</code></pre>
+<pre><samp>* Chris
+* 
+* &amp;lt;b&amp;gt;Github&amp;lt;/b&amp;gt;
+* &lt;b&gt;Github&lt;/b&gt;
+* &lt;b&gt;Github&lt;/b&gt;</samp></pre>
+<blockquote>
+<p>added the <code>{{&amp;company}}</code> to clarify that it is just an alternative syntax with the same result
+as the triple mustache.</p>
+</blockquote>
 
 </main>
 <footer>
@@ -91,73 +137,116 @@ c[<span class="hljs-string">&quot;l&quot;</span>] = <span class="hljs-keyword">p
 
 nbInit
 nbDoc.darkMode
-nbText: <span class="hljs-string">&quot;&quot;&quot;# Example of usage of mustache
+nbText: <span class="hljs-string">&quot;&quot;&quot;# mustache man (5)
 
-From [nim-mustache](https://github.com/soasme/nim-mustache).
+[mustache](https://mustache.github.io/) is a logic-less template system
+with implementations available in multiple languages.
 
-## Usage
+In nim there are two implementations:
 
-Step 1.
+* [nim-mustache](https://github.com/soasme/nim-mustache)
+* [moustachu](https://github.com/fenekku/moustachu)
+
+[nimib](https://pietroppeter.github.io/nimib/) uses `nim-mustache` and takes
+specific advantage of its feature for in-memory partials to store default templates.
+
+Below I will show examples of usage of `mustache` using `nim-mustache`,
+mostly replicating [mustache(5)](https://mustache.github.io/mustache.5.html) man page
+([why (5)?](https://en.wikipedia.org/wiki/Man_page#Manual_sections)).
+&quot;&quot;&quot;</span>
+nbCode: <span class="hljs-keyword">import</span> mustache
+nbText: <span class="hljs-string">&quot;&quot;&quot;
+## SYNOPSIS
+
+A typical mustache template:
 &quot;&quot;&quot;</span>
 nbCode:
-  <span class="hljs-keyword">import</span> mustache, tables
-nbText: <span class="hljs-string">&quot;Step 2.&quot;</span>
-<span class="hljs-keyword">block</span>:
-  nbCode:
-    <span class="hljs-keyword">var</span> c = newContext()
-    c[<span class="hljs-string">&quot;i&quot;</span>] = <span class="hljs-number">1</span>
-    c[<span class="hljs-string">&quot;f&quot;</span>] = <span class="hljs-number">1.0</span>
-    c[<span class="hljs-string">&quot;s&quot;</span>] = <span class="hljs-string">&quot;hello world&quot;</span>
-    c[<span class="hljs-string">&quot;a&quot;</span>] = @[{<span class="hljs-string">&quot;k&quot;</span>: <span class="hljs-string">&quot;v&quot;</span>}.toTable]
-    c[<span class="hljs-string">&quot;t&quot;</span>] = {<span class="hljs-string">&quot;k&quot;</span>: <span class="hljs-string">&quot;v&quot;</span>}.toTable
-    c[<span class="hljs-string">&quot;l&quot;</span>] = <span class="hljs-keyword">proc</span>(s: <span class="hljs-built_in">string</span>, c: <span class="hljs-type">Context</span>): <span class="hljs-built_in">string</span> = <span class="hljs-string">&quot;&lt;b&gt;&quot;</span> &amp; s.render(c) &amp; <span class="hljs-string">&quot;&lt;/b&gt;&quot;</span>
-  nbBlock.code = nbBlock.code.escapeTag
-  nbText: <span class="hljs-string">&quot;Step 3.&quot;</span>
-  nbCode:
-    <span class="hljs-keyword">let</span> s = <span class="hljs-string">&quot;&quot;&quot;
-{{i}} {{f}} {{s}}
-{{#a}}
-  {{k}}
-{{/a}}
-
-{{#t}}
-  {{k}}
-{{/t}}
-
-{{#l}}
-  {{s}}
-{{/l}}
+  <span class="hljs-keyword">var</span> tmpl = <span class="hljs-string">&quot;&quot;&quot;
+Hello {{name}}
+You have just won {{value}} dollars!
+{{#in_california}}
+Well, {{taxed_value}} dollars, after taxes.
+{{/in_california}}
 &quot;&quot;&quot;</span>
-    <span class="hljs-keyword">echo</span>(s.render(c))
+nbText: <span class="hljs-string">&quot;Given the following context:&quot;</span> <span class="hljs-comment"># using context instead of hash</span>
+nbCode:
+  <span class="hljs-keyword">var</span> context = newContext()
+  context[<span class="hljs-string">&quot;name&quot;</span>] = <span class="hljs-string">&quot;Chris&quot;</span>
+  context[<span class="hljs-string">&quot;value&quot;</span>] = <span class="hljs-number">10_000</span>
+  context[<span class="hljs-string">&quot;taxed_value&quot;</span>] = <span class="hljs-number">10000</span> - (<span class="hljs-number">10000</span> * <span class="hljs-number">0.4</span>)
+  context[<span class="hljs-string">&quot;in_california&quot;</span>] = <span class="hljs-literal">true</span>
+nbText: <span class="hljs-string">&quot;Will produce the following:&quot;</span>
+nbCode:
+  <span class="hljs-keyword">echo</span> tmpl.render(context)
+nbText: <span class="hljs-string">&quot;&quot;&quot;
+## DESCRIPTION
 
-<span class="hljs-comment">#[
-nbText: &quot;&quot;&quot;## Other examples
+Mustache can be used for HTML, config files, source code - anything.
+It works by expanding tags in a template using values provided in a context
+object.
 
-not taken from [nim-mustache](https://github.com/soasme/nim-mustache).
-&quot;&quot;&quot;
-block:
-  nbCode:
-    var c = newContext()
-    var s = &quot;&quot;&quot;
-{{highlight}}{{^highlight}}&lt;default&gt;
-{{/highlight}}
-&quot;&quot;&quot;
-    echo s.render c
-  nbBlock.code = nbBlock.code.escapeTag
-  nbBlock.output = nbBlock.output.escapeTag
-  nbText: &quot;In order to get the default tag probably rendered I had to escape it (both in code and output)&quot;
-  nbCode:
-    c[&quot;highlight&quot;] = &quot;&lt;custom&gt;&quot;
-    echo s.render c
-  nbText: &quot;rendering in mustache does automatic escaping&quot;
-  nbCode:
-    s = &quot;{{&gt; highlight }}&quot;
-    echo s.render c
-  nbBlock.output = nbBlock.output.escapeTag
-  nbText: &quot;unless you use a partial (no escaping by mustache, I did it manually in order to have it appear here)&quot;
-]#</span>
-nbSave
-</code></pre>
+We call it &quot;logic-less&quot; because there are no if statements, else clauses, or for loops.
+Instead there are only tags.
+Some tags are replaced with a value, some nothing, and others a series of values.
+This document explains the different types of Mustache tags.
+
+&gt; in this document we use the `context` keyword instead of referring to it as a hash or object
+&gt; as in the original document
+
+## TAG TYPES
+
+Tags are indicated by the double mustaches. `{{person}}` is a **tag**, as is `{{#person}}`.
+In both examples, we'd refer to person as the key or tag key.
+Let's talk about the different types of tags.
+
+### Variables
+
+The most basic tag type is the variable.
+A `{{name}}` tag in a basic template will try to find the **name** key in the current context.
+If there is no **name** key, the parent contexts will be checked recursively.
+If the top context is reached and the **name** key is still not found, nothing will be rendered.
+
+All variables are HTML escaped by default.
+If you want to return unescaped HTML, use the triple mustache: `{{{name}}}`.
+
+You can also use &amp; to unescape a variable: `{{&amp; name}}`.
+This may be useful when changing delimiters (see &quot;Set Delimiter&quot; below).
+
+By default a variable &quot;miss&quot; returns an empty string.
+This can usually be configured in your Mustache library.
+The Ruby version of Mustache supports raising an exception in this situation, for instance.
+
+Template:
+&quot;&quot;&quot;</span> <span class="hljs-comment"># is there a way to raise the exception in nim-mustache?</span>
+nbCode:
+  tmpl = <span class="hljs-string">&quot;&quot;&quot;* {{name}}
+* {{age}}
+* {{company}}
+* {{{company}}}
+* {{&amp;company}}&quot;&quot;&quot;</span>
+nbText: <span class="hljs-string">&quot;Context:&quot;</span>
+nbCode:
+  context = newContext()
+  context[<span class="hljs-string">&quot;name&quot;</span>] = <span class="hljs-string">&quot;Chris&quot;</span>
+  context[<span class="hljs-string">&quot;company&quot;</span>] = <span class="hljs-string">&quot;&lt;b&gt;Github&lt;/b&gt;&quot;</span>
+nbText: <span class="hljs-string">&quot;Output:&quot;</span>
+nbCode:
+  <span class="hljs-keyword">echo</span> tmpl.render(context) <span class="hljs-comment"># the output is not correctly escaped!!! BIG TODO!</span>
+nbText: <span class="hljs-string">&quot;&quot;&quot;
+&gt; added the `{{&amp;company}}` to clarify that it is just an alternative syntax with the same result
+&gt; as the triple mustache.
+&quot;&quot;&quot;</span>
+<span class="hljs-comment">### Sections</span>
+<span class="hljs-comment">#### Non-Empty Lists</span>
+<span class="hljs-comment">#### Lambdas</span>
+<span class="hljs-comment">#### Non-False Values</span>
+<span class="hljs-comment">### Inverted Sections</span>
+<span class="hljs-comment">### Comments</span>
+<span class="hljs-comment">### Partials</span>
+<span class="hljs-comment">### Set Delimiter</span>
+<span class="hljs-comment">## COPYRIGHT</span>
+<span class="hljs-comment">## SEE ALSO</span>
+nbShow</code></pre>
 </section><script>
 function toggleSourceDisplay() {
   var btn = document.getElementById("show")

--- a/docs/mostaccio.nim
+++ b/docs/mostaccio.nim
@@ -159,6 +159,15 @@ nbCode:
 nbText: "Output:"
 nbCode:
   echo tmpl.render(context)
+nbText: """> output is not the expected output:
+
+```
+<b>resque</b>
+<b>hub</b>
+<b>rip</b>
+```
+"""
+
 nbText: """
 #### Lambdas
 
@@ -181,6 +190,13 @@ nbCode:
 nbText: "Output:"
 nbCode:
   echo tmpl.render(context)
+nbText: """> output is not the expected output:
+
+```
+<b>Willy is awesome.</b>
+```
+"""
+
 nbText: """
 #### Non-False Values
 
@@ -239,9 +255,112 @@ nbCode:
 nbText: "Will render as follows:"
 nbCode:
   echo tmpl.render(newContext())
-
+nbText: """
 ### Partials
+
+Partials begin with a greater than sign, like `{{> box}}`.
+
+Partials are rendered at runtime (as opposed to compile time),
+so recursive partials are possible. Just avoid infinite loops.
+
+They also inherit the calling context.
+Whereas in an [ERB](http://en.wikipedia.org/wiki/ERuby) file you may have this:
+
+```
+<%= partial :next_more, :start => start, :size => size %>
+```
+
+Mustache requires only this:
+
+```
+{{> next_more}}
+```
+
+Why? Because the `next_more.mustache` file will inherit
+the size and start methods from the calling context.
+
+In this way you may want to think of partials as
+includes, imports, template expansion, nested templates,
+or subtemplates, even though those aren't literally the case here.
+
+For example, this template and partial:
+"""
+nbCode:
+  let base = """
+<h2>Names</h2>
+{{#names}}
+  {{> user}}
+{{/names}}
+"""
+  let user = "<strong>{{name}}</strong>\n"
+nbText: "Can be thought of as a single, expanded template:"
+nbCode:
+  let expanded = """
+<h2>Names</h2>
+{{#names}}
+  <strong>{{name}}</strong>
+{{/names}}
+"""
+nbText: """
+> `nim-mustache` allows to use partials in-memory.
+> By default nim-mustache looks for `.mustache` files in current directory
+> but the behaviour of where to find partials (which directories or in-memory)
+> can be fully customized
+> (see [here](https://github.com/soasme/nim-mustache#read-partials-from-memory)).
+>
+> Below we show an example where we only search in-memory.
+"""
+nbCode:
+  import tables
+  let partials = {
+    "base": base,
+    "user": user,
+    "expanded": expanded
+  }.toTable
+  
+  context = newContext(searchDirs = @[], partials=partials)
+  context["names"] = %* [
+    { "name": "resque" },
+    { "name": "hub" },
+    { "name": "rip" }
+  ]
+
+  echo "{{>base}}".render(context)
+nbCode:
+  echo "{{>expanded}}".render(context)
+nbText: """
 ### Set Delimiter
+
+Set Delimiter tags start with an equal sign and change the tag delimiters from {{ and }} to custom strings.
+
+Consider the following contrived example:
+
+"""
+nbCode:
+  tmpl = """
+* {{default_tags}}
+{{=<% %>=}}
+* <% erb_style_tags %>
+<%={{ }}=%>
+* {{ default_tags_again }}
+"""
+nbText: """
+Here we have a list with three items. The first item uses the default tag style, the second uses erb style as defined by the Set Delimiter tag, and the third returns to the default style after yet another Set Delimiter declaration.
+
+According to ctemplates, this "is useful for languages like TeX,
+where double-braces may occur in the text and are awkward to use for markup."
+
+Custom delimiters may not contain whitespace or the equals sign.
+
+> adding an example of usage of set delimiter feature
+""" # probably also useful for delayed rendering
+nbCode:
+  context = newContext()
+  context["default_tags"] = "one"
+  context["erb_style_tags"] = "two"
+  context["default_tags_again"] = "three"
+  echo tmpl.render(context)
+
 ## COPYRIGHT
 ## SEE ALSO
 nbShow

--- a/docs/mostaccio.nim
+++ b/docs/mostaccio.nim
@@ -363,5 +363,5 @@ nbCode:
 
 ## COPYRIGHT
 ## SEE ALSO
-nbShow
+nbSave
 # idea: document that shows all spec tests of nim mustache (do this in nblog)

--- a/docs/mostaccio.nim
+++ b/docs/mostaccio.nim
@@ -2,69 +2,113 @@ import nimib
 
 nbInit
 nbDoc.darkMode
-nbText: """# Example of usage of mustache
+nbText: """# mustache man (5)
 
-From [nim-mustache](https://github.com/soasme/nim-mustache).
+[mustache](https://mustache.github.io/) is a logic-less template system
+with implementations available in multiple languages.
 
-## Usage
+In nim there are two implementations:
 
-Step 1.
+* [nim-mustache](https://github.com/soasme/nim-mustache)
+* [moustachu](https://github.com/fenekku/moustachu)
+
+[nimib](https://pietroppeter.github.io/nimib/) uses `nim-mustache` and takes
+specific advantage of its feature for in-memory partials to store default templates.
+
+Below I will show examples of usage of `mustache` using `nim-mustache`,
+mostly replicating [mustache(5)](https://mustache.github.io/mustache.5.html) man page
+([why (5)?](https://en.wikipedia.org/wiki/Man_page#Manual_sections)).
+"""
+nbCode: import mustache
+nbText: """
+## SYNOPSIS
+
+A typical mustache template:
 """
 nbCode:
-  import mustache, tables
-nbText: "Step 2."
-block:
-  nbCode:
-    var c = newContext()
-    c["i"] = 1
-    c["f"] = 1.0
-    c["s"] = "hello world"
-    c["a"] = @[{"k": "v"}.toTable]
-    c["t"] = {"k": "v"}.toTable
-    c["l"] = proc(s: string, c: Context): string = "<b>" & s.render(c) & "</b>"
-  nbBlock.code = nbBlock.code.escapeTag
-  nbText: "Step 3."
-  nbCode:
-    let s = """
-{{i}} {{f}} {{s}}
-{{#a}}
-  {{k}}
-{{/a}}
-
-{{#t}}
-  {{k}}
-{{/t}}
-
-{{#l}}
-  {{s}}
-{{/l}}
+  var tmpl = """
+Hello {{name}}
+You have just won {{value}} dollars!
+{{#in_california}}
+Well, {{taxed_value}} dollars, after taxes.
+{{/in_california}}
 """
-    echo(s.render(c))
+nbText: "Given the following context:" # using context instead of hash
+nbCode:
+  var context = newContext()
+  context["name"] = "Chris"
+  context["value"] = 10_000
+  context["taxed_value"] = 10000 - (10000 * 0.4)
+  context["in_california"] = true
+nbText: "Will produce the following:"
+nbCode:
+  echo tmpl.render(context)
+nbText: """
+## DESCRIPTION
 
-#[
-nbText: """## Other examples
+Mustache can be used for HTML, config files, source code - anything.
+It works by expanding tags in a template using values provided in a context
+object.
 
-not taken from [nim-mustache](https://github.com/soasme/nim-mustache).
+We call it "logic-less" because there are no if statements, else clauses, or for loops.
+Instead there are only tags.
+Some tags are replaced with a value, some nothing, and others a series of values.
+This document explains the different types of Mustache tags.
+
+> in this document we use the `context` keyword instead of referring to it as a hash or object
+> as in the original document
+
+## TAG TYPES
+
+Tags are indicated by the double mustaches. `{{person}}` is a **tag**, as is `{{#person}}`.
+In both examples, we'd refer to person as the key or tag key.
+Let's talk about the different types of tags.
+
+### Variables
+
+The most basic tag type is the variable.
+A `{{name}}` tag in a basic template will try to find the **name** key in the current context.
+If there is no **name** key, the parent contexts will be checked recursively.
+If the top context is reached and the **name** key is still not found, nothing will be rendered.
+
+All variables are HTML escaped by default.
+If you want to return unescaped HTML, use the triple mustache: `{{{name}}}`.
+
+You can also use & to unescape a variable: `{{& name}}`.
+This may be useful when changing delimiters (see "Set Delimiter" below).
+
+By default a variable "miss" returns an empty string.
+This can usually be configured in your Mustache library.
+The Ruby version of Mustache supports raising an exception in this situation, for instance.
+
+Template:
+""" # is there a way to raise the exception in nim-mustache?
+nbCode:
+  tmpl = """* {{name}}
+* {{age}}
+* {{company}}
+* {{{company}}}
+* {{&company}}"""
+nbText: "Context:"
+nbCode:
+  context = newContext()
+  context["name"] = "Chris"
+  context["company"] = "<b>Github</b>"
+nbText: "Output:"
+nbCode:
+  echo tmpl.render(context)
+nbText: """
+> added the `{{&company}}` to clarify that it is just an alternative syntax with the same result
+> as the triple mustache.
 """
-block:
-  nbCode:
-    var c = newContext()
-    var s = """
-{{highlight}}{{^highlight}}<default>
-{{/highlight}}
-"""
-    echo s.render c
-  nbBlock.code = nbBlock.code.escapeTag
-  nbBlock.output = nbBlock.output.escapeTag
-  nbText: "In order to get the default tag probably rendered I had to escape it (both in code and output)"
-  nbCode:
-    c["highlight"] = "<custom>"
-    echo s.render c
-  nbText: "rendering in mustache does automatic escaping"
-  nbCode:
-    s = "{{> highlight }}"
-    echo s.render c
-  nbBlock.output = nbBlock.output.escapeTag
-  nbText: "unless you use a partial (no escaping by mustache, I did it manually in order to have it appear here)"
-]#
-nbSave
+### Sections
+#### Non-Empty Lists
+#### Lambdas
+#### Non-False Values
+### Inverted Sections
+### Comments
+### Partials
+### Set Delimiter
+## COPYRIGHT
+## SEE ALSO
+nbShow

--- a/docs/mostaccio.nim
+++ b/docs/mostaccio.nim
@@ -84,7 +84,8 @@ The Ruby version of Mustache supports raising an exception in this situation, fo
 Template:
 """ # is there a way to raise the exception in nim-mustache?
 nbCode:
-  tmpl = """* {{name}}
+  tmpl = """
+* {{name}}
 * {{age}}
 * {{company}}
 * {{{company}}}
@@ -100,15 +101,148 @@ nbCode:
 nbText: """
 > added the `{{&company}}` to clarify that it is just an alternative syntax with the same result
 > as the triple mustache.
-"""
+
 ### Sections
+
+Sections render blocks of text one or more times, depending on the value of the key in the current context.
+
+A section begins with a pound and ends with a slash.
+That is, `{{#person}}` begins a "person" section while `{{/person}}` ends it.
+
+The behavior of the section is determined by the value of the key.
+
+#### False Values or Empty Lists
+
+If the person key exists and has a value of false or an empty list, the HTML between the pound and slash will not be displayed.
+
+Template:
+"""
+nbCode:
+  tmpl = """
+Shown.
+{{#person}}
+  Never shown!
+{{/person}}"""
+nbText: "Context:"
+nbCode:
+  context = newContext()
+  context["person"] = false
+nbText: "Output:"
+nbCode:
+  echo tmpl.render(context)
+nbText: """
 #### Non-Empty Lists
+
+If the **person** key exists and has a non-false value,
+the HTML between the pound and slash will be rendered and displayed one or more times.
+
+When the value is a non-empty list, the text in the block will be displayed once for each item in the list.
+The context of the block will be set to the current item for each iteration. In this way we can loop over collections.
+
+Template:
+"""
+nbCode:
+  tmpl = """
+{{#repo}}
+  <b>{{name}}</b>
+{{/repo}}"""
+nbText: "Context:"
+nbCode:
+  import json
+  context = newContext()
+  context["repo"] = %* [
+    { "name": "resque" },
+    { "name": "hub" },
+    { "name": "rip" }
+  ]
+# add a note to explain better what is Context and what can be casted to a context value?
+nbText: "Output:"
+nbCode:
+  echo tmpl.render(context)
+nbText: """
 #### Lambdas
+
+When the value is a callable object, such as a function or lambda, the object will be invoked and passed the block of text.
+The text passed is the literal block, unrendered.
+`{{tags}}` will not have been expanded - the lambda should do that on its own. In this way you can implement filters or caching.
+
+Template:
+"""
+nbCode:
+  tmpl = """
+{{#wrapped}}
+  {{name}} is awesome.
+{{/wrapped}}"""
+nbText: "Context:"
+nbCode:
+  context = newContext()
+  context["name"] = "Willy"
+  context["wrapped"] = proc(s: string, c: Context): string = "<b>" & s.render(c) & "</b>"
+nbText: "Output:"
+nbCode:
+  echo tmpl.render(context)
+nbText: """
 #### Non-False Values
+
+When the value is non-false but not a list,
+it will be used as the context for a single rendering of the block.
+
+Template:
+"""
+nbCode:
+  tmpl = """
+{{#person?}}
+  Hi {{name}}!
+{{/person?}}"""
+nbText: "Context:"
+nbCode:
+  context = newContext()
+  context["person?"] = %* { "name": "Jon" }
+nbText: "Output:"
+nbCode:
+  echo tmpl.render(context)
+nbText: """
 ### Inverted Sections
+
+An inverted section begins with a caret (hat) and ends with a slash.
+That is `{{^person}}` begins a "person" inverted section while `{{/person}}` ends it.
+
+While sections can be used to render text one or more times based on the value of the key,
+inverted sections may render text once based on the inverse value of the key.
+That is, they will be rendered if the key doesn't exist, is false, or is an empty list.
+
+Template:
+"""
+nbCode:
+  tmpl = """
+{{#repo}}
+  <b>{{name}}</b>
+{{/repo}}
+{{^repo}}
+  No repos :(
+{{/repo}}"""
+nbText: "Context:"
+nbCode:
+  context = newContext()
+  let empty: seq[string] = @[]
+  context["repo"] = empty  # does not work with seq or array or also with %* []
+nbText: "Output:"
+nbCode:
+  echo tmpl.render(context)
+nbText: """
 ### Comments
+
+Comments begin with a bang and are ignored. The following template:
+"""
+nbCode:
+  tmpl = """<h1>Today{{! ignore me }}.</h1>"""
+nbText: "Will render as follows:"
+nbCode:
+  echo tmpl.render(newContext())
+
 ### Partials
 ### Set Delimiter
 ## COPYRIGHT
 ## SEE ALSO
 nbShow
+# idea: document that shows all spec tests of nim mustache (do this in nblog)

--- a/docs/ptest.html
+++ b/docs/ptest.html
@@ -41,7 +41,7 @@ section#source {
 </header><main>
 <h1>Print-testing for nimib</h1>
 <p>What is print-testing? Testing by comparing printed output of a file with a versioned reference (see <a href="https://github.com/treeform/ptest">treeform/ptest</a>).</p>
-<h2>Test Results ❌</h2>
+<h2>Test Results ✅</h2>
 <table>
 <thead>
 <tr>
@@ -54,36 +54,14 @@ section#source {
 <tbody>
 <tr>
 <td>0</td>
-<td>1</td>
-<td>8</td>
+<td>0</td>
+<td>9</td>
 <td>9</td>
 </tr></tbody></table>
 <pre><samp>&lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;cheatsheet.html&quot;&gt;cheatsheet.nim&lt;/a&gt;
 &lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;hello.html&quot;&gt;hello.nim&lt;/a&gt;
 &lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;index.html&quot;&gt;index.nim&lt;/a&gt;
-&lt;span style=&quot;color:red&quot;&gt;[FAIL]&lt;/span&gt; &lt;a href=&quot;mostaccio.html&quot;&gt;mostaccio.nim&lt;/a&gt;
-Differences found in html file
-output
-:diff --git a/C:/Users/ppeterlongo/nimib/docs/mostaccio.html b/C:/Users/ppeterlongo/nimib/docs/mostaccio.tmp.html
-index 67eab4b..f63d46b 100644
---- a/C:/Users/ppeterlongo/nimib/docs/mostaccio.html
-+++ b/C:/Users/ppeterlongo/nimib/docs/mostaccio.tmp.html
-@@ -231,7 +231,7 @@ nbCode:
-   context[&lt;span class=&quot;hljs-string&quot;&gt;&amp;quot;company&amp;quot;&lt;/span&gt;] = &lt;span class=&quot;hljs-string&quot;&gt;&amp;quot;&amp;lt;b&amp;gt;Github&amp;lt;/b&amp;gt;&amp;quot;&lt;/span&gt;
- nbText: &lt;span class=&quot;hljs-string&quot;&gt;&amp;quot;Output:&amp;quot;&lt;/span&gt;
- nbCode:
--  &lt;span class=&quot;hljs-keyword&quot;&gt;echo&lt;/span&gt; tmpl.render(context)
-+  &lt;span class=&quot;hljs-keyword&quot;&gt;echo&lt;/span&gt; tmpl.render(context) &lt;span class=&quot;hljs-comment&quot;&gt;# the output is not correctly escaped!!! BIG TODO!&lt;/span&gt;
- nbText: &lt;span class=&quot;hljs-string&quot;&gt;&amp;quot;&amp;quot;&amp;quot;
- &amp;gt; added the `{{&amp;amp;company}}` to clarify that it is just an alternative syntax with the same result
- &amp;gt; as the triple mustache.
-warning: LF will be replaced by CRLF in C:/Users/ppeterlongo/nimib/docs/mostaccio.html.
-The file will have its original line endings in your working directory
-warning: LF will be replaced by CRLF in C:/Users/ppeterlongo/nimib/docs/mostaccio.tmp.html.
-The file will have its original line endings in your working directory
-
-err
-:1
+&lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;mostaccio.html&quot;&gt;mostaccio.nim&lt;/a&gt;
 &lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;nolan.html&quot;&gt;nolan.nim&lt;/a&gt;
 &lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;numerical.html&quot;&gt;numerical.nim&lt;/a&gt;
 &lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;penguins.html&quot;&gt;penguins.nim&lt;/a&gt;
@@ -189,29 +167,7 @@ added test candidate: far\from\home.nim</samp></pre>
 <pre><samp>&lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;cheatsheet.html&quot;&gt;cheatsheet.nim&lt;/a&gt;
 &lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;hello.html&quot;&gt;hello.nim&lt;/a&gt;
 &lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;index.html&quot;&gt;index.nim&lt;/a&gt;
-&lt;span style=&quot;color:red&quot;&gt;[FAIL]&lt;/span&gt; &lt;a href=&quot;mostaccio.html&quot;&gt;mostaccio.nim&lt;/a&gt;
-Differences found in html file
-output
-:diff --git a/C:/Users/ppeterlongo/nimib/docs/mostaccio.html b/C:/Users/ppeterlongo/nimib/docs/mostaccio.tmp.html
-index 67eab4b..f63d46b 100644
---- a/C:/Users/ppeterlongo/nimib/docs/mostaccio.html
-+++ b/C:/Users/ppeterlongo/nimib/docs/mostaccio.tmp.html
-@@ -231,7 +231,7 @@ nbCode:
-   context[&lt;span class=&quot;hljs-string&quot;&gt;&amp;quot;company&amp;quot;&lt;/span&gt;] = &lt;span class=&quot;hljs-string&quot;&gt;&amp;quot;&amp;lt;b&amp;gt;Github&amp;lt;/b&amp;gt;&amp;quot;&lt;/span&gt;
- nbText: &lt;span class=&quot;hljs-string&quot;&gt;&amp;quot;Output:&amp;quot;&lt;/span&gt;
- nbCode:
--  &lt;span class=&quot;hljs-keyword&quot;&gt;echo&lt;/span&gt; tmpl.render(context)
-+  &lt;span class=&quot;hljs-keyword&quot;&gt;echo&lt;/span&gt; tmpl.render(context) &lt;span class=&quot;hljs-comment&quot;&gt;# the output is not correctly escaped!!! BIG TODO!&lt;/span&gt;
- nbText: &lt;span class=&quot;hljs-string&quot;&gt;&amp;quot;&amp;quot;&amp;quot;
- &amp;gt; added the `{{&amp;amp;company}}` to clarify that it is just an alternative syntax with the same result
- &amp;gt; as the triple mustache.
-warning: LF will be replaced by CRLF in C:/Users/ppeterlongo/nimib/docs/mostaccio.html.
-The file will have its original line endings in your working directory
-warning: LF will be replaced by CRLF in C:/Users/ppeterlongo/nimib/docs/mostaccio.tmp.html.
-The file will have its original line endings in your working directory
-
-err
-:1
+&lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;mostaccio.html&quot;&gt;mostaccio.nim&lt;/a&gt;
 &lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;nolan.html&quot;&gt;nolan.nim&lt;/a&gt;
 &lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;numerical.html&quot;&gt;numerical.nim&lt;/a&gt;
 &lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;penguins.html&quot;&gt;penguins.nim&lt;/a&gt;

--- a/docs/ptest.html
+++ b/docs/ptest.html
@@ -41,7 +41,7 @@ section#source {
 </header><main>
 <h1>Print-testing for nimib</h1>
 <p>What is print-testing? Testing by comparing printed output of a file with a versioned reference (see <a href="https://github.com/treeform/ptest">treeform/ptest</a>).</p>
-<h2>Test Results ✅</h2>
+<h2>Test Results ❌</h2>
 <table>
 <thead>
 <tr>
@@ -54,19 +54,41 @@ section#source {
 <tbody>
 <tr>
 <td>0</td>
-<td>0</td>
-<td>9</td>
+<td>1</td>
+<td>8</td>
 <td>9</td>
 </tr></tbody></table>
-<pre><samp><span style="color:green">[OK]</span>   <a href="cheatsheet.html">cheatsheet.nim</a>
-<span style="color:green">[OK]</span>   <a href="hello.html">hello.nim</a>
-<span style="color:green">[OK]</span>   <a href="index.html">index.nim</a>
-<span style="color:green">[OK]</span>   <a href="mostaccio.html">mostaccio.nim</a>
-<span style="color:green">[OK]</span>   <a href="nolan.html">nolan.nim</a>
-<span style="color:green">[OK]</span>   <a href="numerical.html">numerical.nim</a>
-<span style="color:green">[OK]</span>   <a href="penguins.html">penguins.nim</a>
-<span style="color:green">[OK]</span>   <a href="pythno.html">pythno.nim</a>
-<span style="color:green">[OK]</span>   <a href="far\from\home.html">far\from\home.nim</a></samp></pre>
+<pre><samp>&lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;cheatsheet.html&quot;&gt;cheatsheet.nim&lt;/a&gt;
+&lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;hello.html&quot;&gt;hello.nim&lt;/a&gt;
+&lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;index.html&quot;&gt;index.nim&lt;/a&gt;
+&lt;span style=&quot;color:red&quot;&gt;[FAIL]&lt;/span&gt; &lt;a href=&quot;mostaccio.html&quot;&gt;mostaccio.nim&lt;/a&gt;
+Differences found in html file
+output
+:diff --git a/C:/Users/ppeterlongo/nimib/docs/mostaccio.html b/C:/Users/ppeterlongo/nimib/docs/mostaccio.tmp.html
+index 67eab4b..f63d46b 100644
+--- a/C:/Users/ppeterlongo/nimib/docs/mostaccio.html
++++ b/C:/Users/ppeterlongo/nimib/docs/mostaccio.tmp.html
+@@ -231,7 +231,7 @@ nbCode:
+   context[&lt;span class=&quot;hljs-string&quot;&gt;&amp;quot;company&amp;quot;&lt;/span&gt;] = &lt;span class=&quot;hljs-string&quot;&gt;&amp;quot;&amp;lt;b&amp;gt;Github&amp;lt;/b&amp;gt;&amp;quot;&lt;/span&gt;
+ nbText: &lt;span class=&quot;hljs-string&quot;&gt;&amp;quot;Output:&amp;quot;&lt;/span&gt;
+ nbCode:
+-  &lt;span class=&quot;hljs-keyword&quot;&gt;echo&lt;/span&gt; tmpl.render(context)
++  &lt;span class=&quot;hljs-keyword&quot;&gt;echo&lt;/span&gt; tmpl.render(context) &lt;span class=&quot;hljs-comment&quot;&gt;# the output is not correctly escaped!!! BIG TODO!&lt;/span&gt;
+ nbText: &lt;span class=&quot;hljs-string&quot;&gt;&amp;quot;&amp;quot;&amp;quot;
+ &amp;gt; added the `{{&amp;amp;company}}` to clarify that it is just an alternative syntax with the same result
+ &amp;gt; as the triple mustache.
+warning: LF will be replaced by CRLF in C:/Users/ppeterlongo/nimib/docs/mostaccio.html.
+The file will have its original line endings in your working directory
+warning: LF will be replaced by CRLF in C:/Users/ppeterlongo/nimib/docs/mostaccio.tmp.html.
+The file will have its original line endings in your working directory
+
+err
+:1
+&lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;nolan.html&quot;&gt;nolan.nim&lt;/a&gt;
+&lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;numerical.html&quot;&gt;numerical.nim&lt;/a&gt;
+&lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;penguins.html&quot;&gt;penguins.nim&lt;/a&gt;
+&lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;pythno.html&quot;&gt;pythno.nim&lt;/a&gt;
+&lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;far\from\home.html&quot;&gt;far\from\home.nim&lt;/a&gt;</samp></pre>
 <hr />
 <h1>Implementation</h1>
 <p>The following is an adaption of <a href="https://github.com/treeform/ptest/blob/master/src/ptest.nim">treeform's ptest.nim</a>
@@ -164,15 +186,37 @@ added test candidate: far\from\home.nim</samp></pre>
   <span class="hljs-literal">stdout</span>.write <span class="hljs-string">&quot;[OK]&quot;</span>.spanColor <span class="hljs-string">&quot;green&quot;</span>
   <span class="hljs-keyword">echo</span> <span class="hljs-string">&quot;   &quot;</span> &amp; fileWithLink
   removeFile(tmp)</code></pre>
-<pre><samp><span style="color:green">[OK]</span>   <a href="cheatsheet.html">cheatsheet.nim</a>
-<span style="color:green">[OK]</span>   <a href="hello.html">hello.nim</a>
-<span style="color:green">[OK]</span>   <a href="index.html">index.nim</a>
-<span style="color:green">[OK]</span>   <a href="mostaccio.html">mostaccio.nim</a>
-<span style="color:green">[OK]</span>   <a href="nolan.html">nolan.nim</a>
-<span style="color:green">[OK]</span>   <a href="numerical.html">numerical.nim</a>
-<span style="color:green">[OK]</span>   <a href="penguins.html">penguins.nim</a>
-<span style="color:green">[OK]</span>   <a href="pythno.html">pythno.nim</a>
-<span style="color:green">[OK]</span>   <a href="far\from\home.html">far\from\home.nim</a></samp></pre>
+<pre><samp>&lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;cheatsheet.html&quot;&gt;cheatsheet.nim&lt;/a&gt;
+&lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;hello.html&quot;&gt;hello.nim&lt;/a&gt;
+&lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;index.html&quot;&gt;index.nim&lt;/a&gt;
+&lt;span style=&quot;color:red&quot;&gt;[FAIL]&lt;/span&gt; &lt;a href=&quot;mostaccio.html&quot;&gt;mostaccio.nim&lt;/a&gt;
+Differences found in html file
+output
+:diff --git a/C:/Users/ppeterlongo/nimib/docs/mostaccio.html b/C:/Users/ppeterlongo/nimib/docs/mostaccio.tmp.html
+index 67eab4b..f63d46b 100644
+--- a/C:/Users/ppeterlongo/nimib/docs/mostaccio.html
++++ b/C:/Users/ppeterlongo/nimib/docs/mostaccio.tmp.html
+@@ -231,7 +231,7 @@ nbCode:
+   context[&lt;span class=&quot;hljs-string&quot;&gt;&amp;quot;company&amp;quot;&lt;/span&gt;] = &lt;span class=&quot;hljs-string&quot;&gt;&amp;quot;&amp;lt;b&amp;gt;Github&amp;lt;/b&amp;gt;&amp;quot;&lt;/span&gt;
+ nbText: &lt;span class=&quot;hljs-string&quot;&gt;&amp;quot;Output:&amp;quot;&lt;/span&gt;
+ nbCode:
+-  &lt;span class=&quot;hljs-keyword&quot;&gt;echo&lt;/span&gt; tmpl.render(context)
++  &lt;span class=&quot;hljs-keyword&quot;&gt;echo&lt;/span&gt; tmpl.render(context) &lt;span class=&quot;hljs-comment&quot;&gt;# the output is not correctly escaped!!! BIG TODO!&lt;/span&gt;
+ nbText: &lt;span class=&quot;hljs-string&quot;&gt;&amp;quot;&amp;quot;&amp;quot;
+ &amp;gt; added the `{{&amp;amp;company}}` to clarify that it is just an alternative syntax with the same result
+ &amp;gt; as the triple mustache.
+warning: LF will be replaced by CRLF in C:/Users/ppeterlongo/nimib/docs/mostaccio.html.
+The file will have its original line endings in your working directory
+warning: LF will be replaced by CRLF in C:/Users/ppeterlongo/nimib/docs/mostaccio.tmp.html.
+The file will have its original line endings in your working directory
+
+err
+:1
+&lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;nolan.html&quot;&gt;nolan.nim&lt;/a&gt;
+&lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;numerical.html&quot;&gt;numerical.nim&lt;/a&gt;
+&lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;penguins.html&quot;&gt;penguins.nim&lt;/a&gt;
+&lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;pythno.html&quot;&gt;pythno.nim&lt;/a&gt;
+&lt;span style=&quot;color:green&quot;&gt;[OK]&lt;/span&gt;   &lt;a href=&quot;far\from\home.html&quot;&gt;far\from\home.nim&lt;/a&gt;</samp></pre>
 <p>results are appended to previously save resultsBlock</p>
 <pre><code class="nim hljs"><span class="hljs-keyword">let</span> (skip, fail, pass) = tests.stats
 <span class="hljs-keyword">if</span> fail &gt; <span class="hljs-number">0</span>:

--- a/src/nimib/renders.nim
+++ b/src/nimib/renders.nim
@@ -1,7 +1,8 @@
 import types, strformat, strutils, markdown, mustache
-export escapeTag
+export escapeTag # where is this used? why do I export? a better solution is to use xmlEncode
 import tables
 import highlight
+from std/cgi import xmlEncode
 
 let mdCfg = initGfmConfig()
 
@@ -13,14 +14,14 @@ proc renderHtmlTextOutput*(output: string): string =
   renderMarkdown(output.strip)
 
 func renderHtmlCodeBodyEscapeTag*(code: string): string =
-  fmt"""<pre><code class="nim">{code.strip.escapeTag}</code></pre>""" & "\n"
+  fmt"""<pre><code class="nim">{code.strip.xmlEncode}</code></pre>""" & "\n"
 
 proc renderHtmlCodeBody*(code: string): string =
   let highlit = highlightNim(code)
   result = fmt"""<pre><code class="nim hljs">{highlit.strip}</code></pre>""" & "\n"
 
 func renderHtmlCodeOutput*(output: string): string =
-  fmt"<pre><samp>{output.strip}</samp></pre>" & "\n"
+  fmt"<pre><samp>{output.strip.xmlEncode}</samp></pre>" & "\n"
 
 proc renderHtmlBlock*(blk: NbBlock): string =
   case blk.kind


### PR DESCRIPTION
* mostaccio nimib document has been update to be the nim-mustache version of mustache man (5) (the language independent syntax guide)
* also **very important**, I changed to escape code output by default. this currently "breaks" only ptest which is not able anymore to show color output, it will be fixed later