### PR TITLE
opt-in nbOutDir and nbBaseDir

### DIFF
--- a/src/nimib.nim
+++ b/src/nimib.nim
@@ -46,7 +46,6 @@ template nbInit*() =
 
   nbDoc.author = nbUser  # never really used it yet, but probably could be a strdefine
   nbDoc.filename = changeFileExt(nbThisFile.string, ".html")
-  echo "doc.filename = ", nbDoc.filename # it is an absolute path instead of an relative path
 
   nbDoc.render = renderHtml
   nbDoc.templateDirs = @["./", "./templates/"]
@@ -84,7 +83,6 @@ template nbInit*() =
     nbDoc.context.searchTable(nbDoc.partials)
     when defined(nimibSrcDir):
       nbDoc.filename = (nbDoc.filename.toAbsoluteDir.relativeTo nimibSrcDirAbs).string
-      echo "nbDoc.filename after = ", nbDoc.filename
     withDir(nbHomeDir):
       write nbDoc
 

--- a/src/nimib.nim
+++ b/src/nimib.nim
@@ -82,7 +82,8 @@ template nbInit*() =
     nbDoc.context.searchDirs(nbDoc.templateDirs)
     nbDoc.context.searchTable(nbDoc.partials)
     when defined(nimibSrcDir):
-      nbDoc.filename = (nbDoc.filename.toAbsoluteDir.relativeTo nimibSrcDirAbs).string
+      if isAbsolute(nbDoc.filename):
+        nbDoc.filename = (AbsoluteFile(nbDoc.filename).relativeTo nimibSrcDirAbs).string
     withDir(nbHomeDir):
       write nbDoc
 

--- a/src/nimib.nim
+++ b/src/nimib.nim
@@ -24,14 +24,12 @@ template nbInit*() =
     nbInitDir {.inject, used.} = getCurrentDir().AbsoluteDir # current directory at initialization
   var nbUser {.inject.}: string = getUser()
 
-
-  const nbOutDir {.strdefine, inject.} = "" # must inject it for it to recognize that we pass in -d:nbOutDir=someDir.
-  # Otherwise it will just be ""
-  const nbBaseDir {.strdefine, inject} = "" # nbSrcDir. Make filename relative to this path
-  when defined(nbBaseDir):
-    let nbBaseDirAbs = nbBaseDir.toAbsoluteDir
-  when defined(nbOutDir):
-    var nbHomeDir {.inject.}: AbsoluteDir = nbOutDir.toAbsoluteDir
+  const nimibOutDir {.strdefine, inject.} = "" # must inject otherwise it is always its default ""
+  const nimibSrcDir {.strdefine, inject} = ""
+  when defined(nimibSrcDir):
+    let nimibSrcDirAbs = nimibSrcDir.toAbsoluteDir
+  when defined(nimibOutDir):
+    var nbHomeDir {.inject.}: AbsoluteDir = nimibOutDir.toAbsoluteDir
   else:
     var nbHomeDir {.inject.}: AbsoluteDir = findNimbleDir(nbThisDir)
     if dirExists(nbHomeDir / "docs".RelativeDir):
@@ -84,8 +82,8 @@ template nbInit*() =
     #   - in case you need to manage additional exceptions for a specific document add a new set of partials before calling nbSave
     nbDoc.context.searchDirs(nbDoc.templateDirs)
     nbDoc.context.searchTable(nbDoc.partials)
-    when defined(nbBaseDir):
-      nbDoc.filename = (nbDoc.filename.toAbsoluteDir.relativeTo nbBaseDirAbs).string
+    when defined(nimibSrcDir):
+      nbDoc.filename = (nbDoc.filename.toAbsoluteDir.relativeTo nimibSrcDirAbs).string
       echo "nbDoc.filename after = ", nbDoc.filename
     withDir(nbHomeDir):
       write nbDoc


### PR DESCRIPTION
This doesn't really solve the path problems we have right now, it's merely a band-aid on top that adds opt-in cmdline flags. In other words, it doesn't change the current behavior if no flags are passed. 

The two flags are:
- `-d:nbOutDir=` which overwrites `nbHomeDir`
- `-d:nbBaseDir=` which is equivalent to `nbSrcDir`.

Still a few things to fix though.