### PR TITLE
add `nbCodeBlock` to emit code in a `block` statement

### DIFF
--- a/src/nimib.nim
+++ b/src/nimib.nim
@@ -66,6 +66,11 @@ template nbInit*() =
   template nbCode(body: untyped) =
     nbCodeBlock(nbBlock, nbDoc, body)
 
+  template nbCodeInBlock(body: untyped) =
+    block:
+      nbCode:
+        body
+
   template nbImage(url: string, caption = "") =
     if isAbsolute(url) or url[0..3] == "http":
       # Absolute URL or External URL


### PR DESCRIPTION
I started writing some first tutorials for `getting-started`. @HugoGranstrom gave me some feedback that for reading purposes it's better to only reference variables defined in the current code block.

With that in mind I realized that it'd be nice to just emit code into a `block` statement so that one doesn't have to write variables `x1` to `xN`. 

I added a `nbCodeBlock` (which I realized is the name internally used as well :see_no_evil:) and a static flag that emits it into a `block` in that case. Seems to work as I expected. So:

```nim
nbCodeBlock:
  let x = 5
nbCodeBlock:
  let x = 10
```
is valid, whereas of course
```nim
nbCode: 
  let x = 5
nbCode:
  let x = 10
```
still throws a redefinition error.