### PR TITLE
Fix build docs in ci

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
       - name: install library dependencies
         run: nimble install -y
       - name: install doc dependencies
-        run: nimble tdeps
+        run: nimble docsdeps
       - name: build docs
         run: nimble docs
       - name: deploy on github pages

--- a/docsrc/index.nim
+++ b/docsrc/index.nim
@@ -6,7 +6,7 @@ nb.title = "Nimib Docs"
 let
   repo = "https://github.com/pietroppeter/nimib"
   docs = "https://pietroppeter.github.io/nimib"
-  hello = read("hello.nim".RelativeFile)
+  hello = read("../docsrc/hello.nim".RelativeFile)
   assets = "docs/static"
   highlight = "highlight.nim.js"
   defaultHighlightCss = "atom-one-light.css"

--- a/nimib.nimble
+++ b/nimib.nimble
@@ -14,7 +14,7 @@ requires "markdown >= 0.8.1"
 requires "mustache >= 0.2.1"
 requires "toml_serialization >= 0.2.0"
 
-task tdeps, "install dependendencies required for testing":
+task docsdeps, "install dependendencies required for doc building":
   exec "nimble -y install ggplotnim@0.4.9 numericalnim@0.6.1 nimoji nimpy"
 
 task test, "General tests":


### PR DESCRIPTION
fix error introduced by #89. also renaming `nimble tdeps` to `nimble docsdeps`.