### PR TITLE
make nimibPreviewCodeAsInSource the default and introduce flag nimibCodeFromAst for previous default, fix #94

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ a recently declassified top-secret cryptoanalytic weapon:"""
 nbCode:
   func decode(secret: openArray[int]): string =
     ## classified by NSA as <strong>TOP SECRET</strong>
-    # so secret that they do not want me to tell you and they will remove this message!
     for c in secret:
       result.add char(c)
 
@@ -90,12 +89,12 @@ nbText: """
 
 nbCode:
   let msg = decode secret
-  echo msg
+  echo msg  # what will it say?
 
 nbText:
   fmt"_Hey_, there must be a bug somewhere, the message (`{msg}`) is not even addressed to me!"
 
-nbSave # use nbShow to automatically open a browser tab with html output
+nbSave
 
 ```
 

--- a/docsrc/hello.nim
+++ b/docsrc/hello.nim
@@ -27,7 +27,6 @@ a recently declassified top-secret cryptoanalytic weapon:"""
 nbCode:
   func decode(secret: openArray[int]): string =
     ## classified by NSA as <strong>TOP SECRET</strong>
-    # so secret that they do not want me to tell you and they will remove this message!
     for c in secret:
       result.add char(c)
 
@@ -38,9 +37,9 @@ nbText: """
 
 nbCode:
   let msg = decode secret
-  echo msg
+  echo msg  # what will it say?
 
 nbText:
   fmt"_Hey_, there must be a bug somewhere, the message (`{msg}`) is not even addressed to me!"
 
-nbSave # use nbShow to automatically open a browser tab with html output
+nbSave

--- a/docsrc/numerical.nim
+++ b/docsrc/numerical.nim
@@ -115,7 +115,8 @@ nbText: "To compute percentage error of each method at $y(5)$ I will use:"
 nbCode:
   proc pe(yApprox: float): string = fmt"{(100.0*abs(yApprox - y5) / abs(y5)):.3f}%"
   echo pe y1hn[^1]  ## used like this
-nbTextWithCode: fmt"""
+nbTextWithCode: # note that we need to start the multi line on next line
+  fmt"""
 The following table is built as a Markdown table in a `nbText` block.
 
 **Table 1.** Percentage errors

--- a/nimib.nimble
+++ b/nimib.nimble
@@ -18,13 +18,13 @@ task docsdeps, "install dependendencies required for doc building":
   exec "nimble -y install ggplotnim@0.4.9 numericalnim@0.6.1 nimoji nimpy karax@#head"
 
 task test, "General tests":
-  exec "nim r -d:nimibPreviewCodeAsInSource tests/tsources.nim"
+  exec "nim r tests/tsources.nim"
   exec "nim r tests/tblocks.nim"
-  exec "nim r -d:nimibPreviewCodeAsInSource tests/tblocks.nim"
+  exec "nim r -d:nimibCodeFromAst tests/tblocks.nim"
   exec "nim r tests/tnimib.nim"
-  exec "nim r -d:nimibPreviewCodeAsInSource tests/tnimib.nim"
+  exec "nim r -d:nimibCodeFromAst tests/tnimib.nim"
   exec "nim r tests/trenders.nim"
-  exec "nim r -d:nimibPreviewCodeAsInSource tests/trenders.nim"
+  exec "nim r -d:nimibCodeFromAst tests/trenders.nim"
 
 task readme, "update readme":
   exec "nim -d:useMdBackend r docsrc/index.nim"  

--- a/src/nimib.nim
+++ b/src/nimib.nim
@@ -12,6 +12,9 @@ from nimib / renders import nil
 from mustachepkg/values import searchTable, searchDirs, castStr
 export searchTable, searchDirs, castStr
 
+when defined(nimibPreviewCodeAsInSource):
+  {.warning: "-d:nimibPreviewCodeAsInSource is now default (since 0.3), old default is available with -d:nimibCodeFromAst".}
+
 template moduleAvailable*(module: untyped): bool =
   (compiles do: import module)
 

--- a/src/nimib.nim
+++ b/src/nimib.nim
@@ -12,9 +12,6 @@ from nimib / renders import nil
 from mustachepkg/values import searchTable, searchDirs, castStr
 export searchTable, searchDirs, castStr
 
-when defined(nimibPreviewCodeAsInSource):
-  {.warning: "-d:nimibPreviewCodeAsInSource is now default (since 0.3), old default is available with -d:nimibCodeFromAst".}
-
 template moduleAvailable*(module: untyped): bool =
   (compiles do: import module)
 

--- a/src/nimib/blocks.nim
+++ b/src/nimib/blocks.nim
@@ -31,3 +31,6 @@ template newNbBlock*(cmd: string, readCode: static[bool], nbDoc, nbBlock, body, 
   nbBlock.context["code"] = nbBlock.code
   nbBlock.context["output"] = nbBlock.output.dup(removeSuffix)
   nbDoc.blocks.add nbBlock
+
+when defined(nimibPreviewCodeAsInSource):
+  {.warning: "-d:nimibPreviewCodeAsInSource is now default (since 0.3), old default is available with -d:nimibCodeFromAst".}

--- a/src/nimib/blocks.nim
+++ b/src/nimib/blocks.nim
@@ -21,10 +21,10 @@ template newNbBlock*(cmd: string, readCode: static[bool], nbDoc, nbBlock, body, 
   nbBlock = NbBlock(command: cmd, context: newContext(searchDirs = @[], partials = nbDoc.partials))
   when readCode:
     nbBlock.code = nbNormalize:
-      when defined(nimibPreviewCodeAsInSource):
-        getCodeAsInSource(nbDoc.source, cmd, body)
-      else:
+      when defined(nimibCodeFromAst):
         toStr(body)
+      else:
+        getCodeAsInSource(nbDoc.source, cmd, body)
   echo peekFirstLineOf(nbBlock.code)
   blockImpl
   if len(nbBlock.output) > 0: echo "     -> ", peekFirstLineOf(nbBlock.output)

--- a/tests/tnimib.nim
+++ b/tests/tnimib.nim
@@ -13,23 +13,22 @@ suite "nbText":
     nbText: fmt"hi {name}"
     check nb.blk.output == "hi you"
 
-  when defined(nimibCodeFromAst):
-    test "multi line text string":
-      nbText: """hi
+  test "multi line text string":
+    nbText: """hi
 how are you?
 """
-      check nb.blk.output == """hi
+    check nb.blk.output == """hi
 how are you?
 """
 
-    test "multi line text string with strformat":
-      let
-        name = "you"
-        answer = "fine"
-      nbText: &"""hi {name}
+  test "multi line text string with strformat":
+    let
+      name = "you"
+      answer = "fine"
+    nbText: &"""hi {name}
 how are you? {answer}
 """
-      check nb.blk.output == """hi you
+    check nb.blk.output == """hi you
 how are you? fine
 """
 
@@ -45,8 +44,28 @@ suite "nbTextWithCode":
       check nb.blk.code == "fmt\"hi {name}\""
       check nb.blk.output == "hi you"
 
+  test "multi line text string - variant 1":
+    nbTextWithCode:
+      """hi
+how are you?
+"""
+    check nb.blk.code == "\"\"\"hi\nhow are you?\n\"\"\""
+    check nb.blk.output == """hi
+how are you?
+"""
+
   when defined(nimibCodeFromAst):
-    test "multi line text string":
+    test "multi line text string - variant 2":
+      nbTextWithCode: """
+hi
+how are you?
+"""
+      check nb.blk.code == "\"\"\"hi\nhow are you?\n\"\"\""
+      check nb.blk.output == """hi
+how are you?
+"""
+
+    test "multi line text string - variant 3":
       nbTextWithCode: """hi
 how are you?
 """

--- a/tests/tnimib.nim
+++ b/tests/tnimib.nim
@@ -8,12 +8,12 @@ suite "nbText":
     nbText: "hi"
     check nb.blk.output == "hi"
 
-  when not defined(nimibPreviewCodeAsInSource):
-    test "single line text string with strformat":
-      let name = "you"
-      nbText: fmt"hi {name}"
-      check nb.blk.output == "hi you"
+  test "single line text string with strformat":
+    let name = "you"
+    nbText: fmt"hi {name}"
+    check nb.blk.output == "hi you"
 
+  when defined(nimibCodeFromAst):
     test "multi line text string":
       nbText: """hi
 how are you?
@@ -39,13 +39,13 @@ suite "nbTextWithCode":
     check nb.blk.code == "\"hi\""
     check nb.blk.output == "hi"
 
-  when not defined(nimibPreviewCodeAsInSource):
-    test "single line text string with strformat":
+  test "single line text string with strformat":
       let name = "you"
       nbTextWithCode: fmt"hi {name}"
       check nb.blk.code == "fmt\"hi {name}\""
       check nb.blk.output == "hi you"
 
+  when defined(nimibCodeFromAst):
     test "multi line text string":
       nbTextWithCode: """hi
 how are you?


### PR DESCRIPTION
fix #94.

With upcoming 0.3 release, it might be a good moment also to make default the `nimibPreviewCodeAsInSource` switch
and introduce a new switch `nimibCodeFromAst` for old default.

We know it has edge cases where it will fail but it does not seem to be an issue for code as it is usually formatted (and the alternative `CodeFromAst` also has some issue - which did raise bugs directly in nim).
We will test if issues arises in nimibook and scinim/getting-started before making the official release.
