### PR TITLE
improving docs for v0.3 + fix markdown backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,44 @@
-
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+  <title>Nimib Docs</title>
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2280%22>🐳</text></svg>">
+  <meta content="text/html; charset=utf-8" http-equiv="content-type">
+  <meta content="width=device-width, initial-scale=1" name="viewport">
+  <link rel='stylesheet' href='https://unpkg.com/normalize.css/'>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/kognise/water.css@latest/dist/light.min.css">
+  <link rel='stylesheet' href='https://cdn.jsdelivr.net/gh/pietroppeter/nimib/assets/atom-one-light.css'>
+  <style>
+.nb-box {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.nb-small {
+  font-size: 0.8rem;
+}
+button.nb-small {
+  float: right;
+  padding: 2px;
+  padding-right: 5px;
+  padding-left: 5px;
+}
+section#source {
+  display:none
+}
+</style>
+  
+  <script async defer data-domain="pietroppeter.github.io/nimib" src="https://plausible.io/js/plausible.js"></script>
+</head>
+<body>
+<header>
+<div class="nb-box">
+  <span><a href=".">🏡</a></span>
+  <span><code>index.nim</code></span>
+  <span><a href="https://github.com/pietroppeter/nimib"><svg aria-hidden="true" width="1.2em" height="1.2em" style="vertical-align: middle;" preserveAspectRatio="xMidYMid meet" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59c.4.07.55-.17.55-.38c0-.19-.01-.82-.01-1.49c-2.01.37-2.53-.49-2.69-.94c-.09-.23-.48-.94-.82-1.13c-.28-.15-.68-.52-.01-.53c.63-.01 1.08.58 1.23.82c.72 1.21 1.87.87 2.33.66c.07-.52.28-.87.51-1.07c-1.78-.2-3.64-.89-3.64-3.95c0-.87.31-1.59.82-2.15c-.08-.2-.36-1.02.08-2.12c0 0 .67-.21 2.2.82c.64-.18 1.32-.27 2-.27c.68 0 1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82c.44 1.1.16 1.92.08 2.12c.51.56.82 1.27.82 2.15c0 3.07-1.87 3.75-3.65 3.95c.29.25.54.73.54 1.48c0 1.07-.01 1.93-.01 2.2c0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z" fill="#000"></path></svg></a></span>
+</div>
+<hr>
+</header><main>
 # nimib 🐳 - nim 👑 driven ⛵ publishing ✍
 
 Nimib provides an API to convert your Nim code and its outputs to html documents.
@@ -32,7 +72,7 @@ This document is generated though nimib both as an index.html file and as a READ
 you should be reading one of the two, for the other:
 
 * [README.md](https://github.com/pietroppeter/nimib)
-* [index.html](https://pietroppeter.github.io/nimib)
+* [index.html](.)
 
 Nimib was presented in [NimConf2021](https://conf.nim-lang.org),
 see [video](https://www.youtube.com/watch?v=sWA58Wtk6L8)
@@ -44,58 +84,12 @@ provides markdown highlighting in nimib file and a preview mechanism.
 
 ## 👋 🌍 Example Usage
 
-First have a look at the following html document: [hello.html](https://pietroppeter.github.io/nimib/hello.html)
+First have a look at the following html document: [hello.html](./hello.html)
 
 This was produced with `nim r docs/hello`, where [docs/hello.nim](https://github.com/pietroppeter/nimib/blob/main/docs/hello.nim) is:
 
-
 ```nim
-import strformat, strutils
-import nimib
-
-nbInit
-
-nbText: """
-## Secret talk with a computer
-Let me show you how to talk with the computer like a [real hacker](https://mango.pdf.zone/)
-and incidentally you might learn the basics of [nimib](https://github.com/pietroppeter/nimib).
-### A secret message
-Inside this document is hidden a secret message. I will ask the computer to spit it out:
-"""
-
-let secret = [104, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100]
-
-nbCode:
-  echo secret
-
-nbText: fmt"""
-what does this integer sequence mean?
-Am I supposed to [recognize it](https://oeis.org/search?q={secret.join("%2C+")}&language=english&go=Search)?
-
-### A cryptoanalytic weapon
-Luckily I happen to have a [nim](https://nim-lang.org/) implementation of
-a recently declassified top-secret cryptoanalytic weapon:"""
-
-nbCode:
-  func decode(secret: openArray[int]): string =
-    ## classified by NSA as <strong>TOP SECRET</strong>
-    for c in secret:
-      result.add char(c)
-
-nbText: """
-  ### The great revelation
-  Now I can just apply it to my secret message and
-  finally decrypt what the computer wants to tell me:"""
-
-nbCode:
-  let msg = decode secret
-  echo msg  # what will it say?
-
-nbText:
-  fmt"_Hey_, there must be a bug somewhere, the message (`{msg}`) is not even addressed to me!"
-
-nbSave
-
+discard
 ```
 
 
@@ -103,11 +97,15 @@ nbSave
 
 in this repo:
 
-* [index](https://pietroppeter.github.io/nimib/index.html): generate an HTML and a README.md at the same time (you are reading one of the two)
-* [penguins](https://pietroppeter.github.io/nimib/penguins.html): explore palmer penguins dataset using ggplotnim (example of showing images)
-* [numerical](https://pietroppeter.github.io/nimib/numerical.html): example usage of NumericalNim (example of custom style, usage of latex)
-* [cheatsheet](https://pietroppeter.github.io/nimib/cheatsheet.html): markdown cheatsheet (example of a custom block, custom highlighting and a simple TOC)
-* [mostaccio](https://pietroppeter.github.io/nimib/mostaccio.html): examples of usage of nim-mustache and of dark mode.
+* [index](./index.html): generate an HTML and a README.md at the same time (you are reading one of the two)
+* [penguins](./penguins.html): explore palmer penguins dataset using ggplotnim (example of showing images)
+* [numerical](./numerical.html): example usage of NumericalNim (example of custom style, usage of latex)
+* [cheatsheet](./cheatsheet.html): markdown cheatsheet (example of a custom block, custom highlighting and a simple TOC)
+* [mostaccio](./mostaccio.html): examples of usage of nim-mustache and of dark mode.
+* [interactivity](./interactivity.html): shows the basic API of creating interactive elements using `nbCodeToJs`.
+* [counter](./counters.html): shows how to create reusable interactive widgets by creating a counter button.
+* [caesar](./caesar.html): a Caesar cipher implemented using `nbCodeToJs` and `karax`.
+
 
 elsewhere:
 
@@ -128,9 +126,10 @@ you are welcome to add here what you have built with nimib!
 The following are the main elements of a default nimib document:
 
 * `nbInit`: initializes a nimib document, required for all other commands to work.
-* `nbCode`: code blocks with automatic stdout capture
+  In particular it creates and injects into scope a `nb` object used by all other blocks
+  (see below section API for internal details).
+* `nbCode`: code blocks with automatic stdout capture and capture of code source
 * `nbText`: text blocks with automatic conversion from markdown to html (thanks to [nim-markdown](https://github.com/soasme/nim-markdown))
-* `nbImage`: image command to show images
 * `nbSave`: save the document (by default to html)
 * styling with [water.css](https://watercss.kognise.dev/), light mode is default, dark mode available (`nb.darkMode` after `nbInit`).
 * static highlighting of nim code. Highlight styling classes are the same of [highlightjs](https://highlightjs.org/)
@@ -144,9 +143,41 @@ Customization over the default is mostly achieved through nim-mustache or changi
 `NbDoc` and `NbBlock` elements (see below api).
 Currently most of the documentation on customization is given by the examples.
 
+### other templates
+
+* `nbImage`: image command to show images (see `penguins.nim` example linked above)
+* `nbFile`: content (string or untyped) is saved to file (see example document [files](./files.html))
+* `nbRawOutput`: called with string content, it will add the raw content to document (html backend)
+* `nbTextWithCode`: a variant of `nbText` that also reads nim source. See example of usage
+  at the end of the source in `numerical.nim` linked above.
+* `nbPython`:  can be used after calling `nbInitPython()` and it runs and capture output of python code;
+  requires [nimpy](https://github.com/yglukhov/nimpy).
+
+### creating custom blocks
+
+* `newNbCodeBlock(cmd: string, body, blockImpl: untyped)`: template that can be used to create custom
+  code block that will need both a `body` and an implementation which might make use of `body`.
+  Also, the source code in `body` is read.
+  Example blocks created with `newNbCodeBlock` are `nbCode` and `nbTextWithCode`.
+* `newNbSlimBlock(cmd: string, blockImpl: untyped)`: template that can be used to create
+  a custom block that does not need a separate `body`.
+  Example blocks created with `newNbSlimBlock` are `nbText`, `nbImage` and `nbFile`.
+
+See `src/nimib.nim` for examples on nimib blocks that are built using these two templates.
+
+### interactivity using nim js backend
+
+Nimib can incorporate javascript code generated from nim code using template `nbCodeToJs`.
+It also provides a template `nbKaraxCode` to add code based on [karax](https://github.com/karaxnim/karax).
+
+See [interactivity](./interactivity.html) for an explanation of the api
+and [counter](./counters.html) for examples of how to create widgets using it.
+In [caesar](./caesar.html) we have an example of a karax app
+that implements [Caesar cipher](https://en.wikipedia.org/wiki/Caesar_cipher).
+
 ### latex
 
-See [numerical](https://pietroppeter.github.io/nimib/numerical.html) for an example of latex usage.
+See [numerical](./numerical.html) for an example of latex usage.
 
 To add latex support:
 
@@ -180,8 +211,46 @@ Inside a config file you can define two special directory:
 
 `nbInit` also parses command line options that start with `nb` or `nimib`
 that allow to override the above value, skip the config file or other options.
-To see all the options execute any nimib file with option `nbHelp`.
 
+All the options available can be seen by running any nimib file with option `nbHelp`
+(execution will stop after `nbInit`).
+
+```nim
+import osproc
+withDir nb.srcDir:
+  echo execProcess(&quot;nim r --verbosity:0 --hints:off --warning:UnusedImport:off hello --nbHelp&quot;)
+```
+
+
+```
+Nimib options:
+
+  --nbHelp,     --nimibHelp                 print this help
+  --nbSkipCfg,  --nimibSkipCfg              skip nimib config file
+  --nbCfgName,  --nimibCfgName              change name of config file (default &quot;nimib.toml&quot;)
+  --nbSrcDir,   --nimibSrcDir               set srcDir as relative (to CfgDir) or absolute; overrides config 
+  --nbHomeDir,  --nimibHomeDir              set homeDir as relative (to CfgDir) or absolute; overrides config 
+  --nbFilename, --nimibFilename             overrides name of output file (e.g. somefile --nbFilename:othername.html)
+  --nbShow,     --nimibShow                 open in browser at the end of nbSave
+```
+
+
+
+The value of options are available in `nb.options` field which also
+tracks further options in `nb.options.other: seq[tuple[kind: CmdLineKind; name, value: string]]`.
+
+### Code capture
+
+The code capture of a block like `nbCode` (or other custom blocks)
+can happen in two different ways:
+
+* `CodeAsInSource` (default since version 0.3): code for a single block
+  is parsed from file source (available in `nb.source`).
+* `CodeFromAst` (default in versions 0.1 and 0.2): code for a single block
+  is rendered from AST of body. This means that only documentation comments
+  are shown (since normal comments are not part of the AST) and that the source show
+  might be different from original source.
+  Since version 0.3 this is available through compile time switch `nimibCodeFromAst`.
 
 ## 🐝 API <!-- Api means bees in Italian -->
 
@@ -191,8 +260,6 @@ To see all the options execute any nimib file with option `nbHelp`.
 * the last processed block is available as `nb.blk`
 * `nb.blk.output` contains the (non rendered) output of block
 * `nb.blk.code` contains the source code of the block
-* currently the source code is a stringification of AST and as such it might be
-  formatted differently than the actual source
 * Work is ongoing to have the code source exactly as in source file (see PR ([#63](https://github.com/pietroppeter/nimib/pull/63)))
 * `NbBlock` is a ref object, so changing `nb.blk`, changes the last block in `nb.blocks`.
 * rendering happens during the call of `nbSave` and and calls a `nb.render` proc
@@ -213,46 +280,28 @@ To see all the options execute any nimib file with option `nbHelp`.
 
 Here are two examples that show how to hijack the api:
 
-* [nolan](https://pietroppeter.github.io/nimib/nolan.html): how to mess up the timeline of blocks ⏳
-* [pythno](https://pietroppeter.github.io/nimib/pythno.html): a reminder that nim is not python 😜
+* [nolan](./nolan.html): how to mess up the timeline of blocks ⏳
+* [pythno](./pythno.html): a reminder that nim is not python 😜
 
-## Changelog
+## Changelog and 🙏 Thanks
 
-### 0.2
-
-most of the changes break the api
-
-* instead of creating and injecting multiple variables
-  (`nbDoc`, `nbBlock`, `nbHomeDir`, ...), nimib now only injects a `nb` variable
-  that is a `NbDoc`. Some aliases are provided to minimize breakage.
-* handling of paths (`srcDir` and `homeDir`) is changed and is based on the presence
-  of a new config file `nimib.toml`
-* command line options are now processed and can be used to skip/override the config process.
-  Run any nimib file with option `--nbHelp` to see available options.
-* `nbPostInit` and `nbPreSave` customization mechanism based on includes are now removed 
+In the [changelog](changelog.md) you find all recent changes, some early history of nimib, pointers to relevant
+examples of usage of nimib and heartfelt thanks to some of the fine folks that
+made this development possible.
 
 ## 🌅 Roadmap
 
-- refactor rendering of blocks and simplify api extensions ([#24](https://github.com/pietroppeter/nimib/issues/24))
 - add more themes such as [nimibook](https://github.com/pietroppeter/nimibook).
   In particular themes for blogging and for creating general websites.
-- client-side dynamic site: interactivity of documents, e.g. a dahsboard (possibly taking advantage of nim js backend)
-- can I use nimib to build a library directly from documentation?
+- can I use nimib to build a library directly from documentation (like in [nbdev](https://github.com/fastai/nbdev))?
 - nimib executable for scaffolding and to support different publishing workflows
 - server-side dynamic sites (streamlit style? take advantage of caching instead of hot code reloading)
 - possibility of editing document in the browser (similar to jupyter UI, not necessarily taking advantage of hot code reloading)
 - ...
 
-## 🙏 Thanks
-
-to:
-
-* [soasme](https://github.com/soasme) for the excellent libraries nim-markdown and nim-mustache, which provide the backbone of nimib rendering and customization
-* [Clonkk](https://github.com/Clonkk) for help in a critical piece of code early on (see [this Stack Overflow answer](https://stackoverflow.com/a/64032172/4178189))
-* [yardanico](https://github.com/yardanico) for being the first contributor and great sponsor of this library, even before an official release
-* [vindaar](https://github.com/Vindaar),
-  [hugogranstrom](https://github.com/HugoGranstrom)
-  for their contributions towards version 0.2.
+completed in 0.3:
+- [x] refactor rendering of blocks and simplify api extensions ([#24](https://github.com/pietroppeter/nimib/issues/24))
+- [x] client-side dynamic site: interactivity of documents, e.g. a dahsboard (possibly taking advantage of nim js backend)
 
 ## ❓ ❗ Q & A
 
@@ -291,4 +340,348 @@ because I made a [package](https://github.com/pietroppeter/nimoji) for that and 
 
 because [someone made it into an art form](https://github.com/oakes/vim_cubed#q--a)
 and they tell me [imitation is the sincerest form of flattery](https://www.goodreads.com/quotes/558084-imitation-is-the-sincerest-form-of-flattery-that-mediocrity-can)
+</main>
+<footer>
+<hr>
+<div class="nb-box">
+  <span><span class="nb-small">made with <a href="https://pietroppeter.github.io/nimib/">nimib 🐳</a></span></span>
+  <span></span>
+  <span><button class="nb-small" id="show" onclick="toggleSourceDisplay()">Show Source</button></span>
+</div>
+</footer>
+<section id="source">
+<pre><code class="nim hljs"><span class="hljs-keyword">import</span> nimib, strformat, nimoji, nimib / renders
 
+<span class="hljs-keyword">when</span> <span class="hljs-keyword">defined</span>(mdOutput):
+  nbInit(backend=useMdBackend)
+<span class="hljs-keyword">else</span>:
+  nbInit
+nb.title = <span class="hljs-string">&quot;Nimib Docs&quot;</span>
+
+<span class="hljs-keyword">let</span>
+  repo = <span class="hljs-string">&quot;https://github.com/pietroppeter/nimib&quot;</span>
+  docs = <span class="hljs-keyword">if</span> <span class="hljs-keyword">defined</span>(useMdBackend): <span class="hljs-string">&quot;https://pietroppeter.github.io/nimib&quot;</span> <span class="hljs-keyword">else</span>: <span class="hljs-string">&quot;.&quot;</span>
+  hello = read(nb.srcDir / <span class="hljs-string">&quot;hello.nim&quot;</span>.<span class="hljs-type">RelativeFile</span>)
+  assets = <span class="hljs-string">&quot;docs/static&quot;</span>
+  highlight = <span class="hljs-string">&quot;highlight.nim.js&quot;</span>
+  defaultHighlightCss = <span class="hljs-string">&quot;atom-one-light.css&quot;</span>
+
+nbText: <span class="hljs-string">hlMdF&quot;&quot;&quot;
+# nimib :whale: - nim :crown: driven :sailboat: publishing :writingHand:
+
+Nimib provides an API to convert your Nim code and its outputs to html documents.
+
+The type of html output that is obtained by default is similar to html notebooks produced by tools
+like [Jupyter](https://nbviewer.jupyter.org/url/norvig.com/ipython/Advent%20of%20Code.ipynb)
+or [RMarkdown](https://rmarkdown.rstudio.com/lesson-10.html), but nimib provides this starting
+directly from standard nim files. It currently does not provide any type of interactivity or automatic reloading.
+
+If you have some nim code lying around that echoes stuff you can try how nimib works with following these steps:
+  * run in shell `nimble install nimib`
+  * add `import nimib` at the top of your nim file
+  * add a `nbInit` command right after that
+  * split your code into one or more `nbCode:` blocks
+  * add some text commentary in markdown through `nbText:` blocks
+  * add a `nbSave` command at the end
+  * compile and run
+  * open the html file that has been generated next to your nim file (same name)
+  * (you can use runtime option `--nbShow` to open the html file automatically in your default browser)
+
+See below for an example of this.
+
+Nimib strives for:
+  * a simple API
+  * sane defaults
+  * easy customization
+
+The main goal of Nimib is to empower people to explore nim and its ecosystem and share with others.
+
+This document is generated though nimib both as an index.html file and as a README.md,
+you should be reading one of the two, for the other:
+
+* [README.md]({repo})
+* [index.html]({docs})
+
+Nimib was presented in [NimConf2021](https://conf.nim-lang.org),
+see [video](https://www.youtube.com/watch?v=sWA58Wtk6L8)
+and [slides](https://github.com/pietroppeter/nimconf2021). 
+
+The vs code extension
+[nimiboost](https://marketplace.visualstudio.com/items?itemName=hugogranstrom.nimiboost)
+provides markdown highlighting in nimib file and a preview mechanism.
+
+## :wave: :earthAfrica: Example Usage
+
+First have a look at the following html document: [hello.html]({docs}/hello.html)
+
+This was produced with `nim r docs/hello`, where [docs/hello.nim]({repo}/blob/main/docs/hello.nim) is:
+&quot;&quot;&quot;</span>.emojize
+
+
+<span class="hljs-keyword">when</span> <span class="hljs-keyword">not</span> <span class="hljs-keyword">defined</span>(useMdBackend):
+  nbCode: <span class="hljs-keyword">discard</span>
+  nb.blk.code = hello  <span class="hljs-comment"># &quot;\n&quot; should not be needed here (fix required in rendering)</span>
+<span class="hljs-keyword">else</span>:
+  nbText &amp;<span class="hljs-string">&quot;&quot;&quot;
+```nim
+{hello}
+```&quot;&quot;&quot;</span>
+
+
+nbText: <span class="hljs-string">hlMdF&quot;&quot;&quot;
+### Other examples of usage
+
+in this repo:
+
+* [index]({docs}/index.html): generate an HTML and a README.md at the same time (you are reading one of the two)
+* [penguins]({docs}/penguins.html): explore palmer penguins dataset using ggplotnim (example of showing images)
+* [numerical]({docs}/numerical.html): example usage of NumericalNim (example of custom style, usage of latex)
+* [cheatsheet]({docs}/cheatsheet.html): markdown cheatsheet (example of a custom block, custom highlighting and a simple TOC)
+* [mostaccio]({docs}/mostaccio.html): examples of usage of nim-mustache and of dark mode.
+* [interactivity]({docs}/interactivity.html): shows the basic API of creating interactive elements using `nbCodeToJs`.
+* [counter]({docs}/counters.html): shows how to create reusable interactive widgets by creating a counter button.
+* [caesar]({docs}/caesar.html): a Caesar cipher implemented using `nbCodeToJs` and `karax`.
+
+
+elsewhere:
+
+* [adventofnim](https://pietroppeter.github.io/adventofnim/index.html): solutions for advent of code in nim
+* [intro to binarylang](https://ajusa.github.io/binarylang-fun/intro.html): a introduction to library [binarylang](https://github.com/sealmove/binarylang) (first public usage of nimib I was aware of)
+* [nblog](https://github.com/pietroppeter/nblog): a blog about nimib and its ecosystem
+* [nimibook](https://github.com/pietroppeter/nimibook): a port of mdbook to nim(ib)
+* [SciNim Getting Started](https://scinim.github.io/getting-started/): tutorials for nim in scientific computing 
+* [Norm documentation](https://norm.nim.town): documentation of a Nim ORM library.
+* [NimiSlides](https://github.com/HugoGranstrom/nimib-reveal): a [reveal.js](https://revealjs.com) theme for nimib.
+
+you are welcome to add here what you have built with nimib!
+
+## :hammer_and_wrench: Features
+
+&gt; “I try all things, I achieve what I can.” ― Herman Melville, Moby-Dick or, the Whale
+
+The following are the main elements of a default nimib document:
+
+* `nbInit`: initializes a nimib document, required for all other commands to work.
+  In particular it creates and injects into scope a `nb` object used by all other blocks
+  (see below section API for internal details).
+* `nbCode`: code blocks with automatic stdout capture and capture of code source
+* `nbText`: text blocks with automatic conversion from markdown to html (thanks to [nim-markdown](https://github.com/soasme/nim-markdown))
+* `nbSave`: save the document (by default to html)
+* styling with [water.css](https://watercss.kognise.dev/), light mode is default, dark mode available (`nb.darkMode` after `nbInit`).
+* static highlighting of nim code. Highlight styling classes are the same of [highlightjs](https://highlightjs.org/)
+  and you can pick a different styling (`atom-one-light` is default for light mode, `androidstudio` is default for dark mode).
+* (optional) latex rendering through [katex](https://katex.org/) (see below)
+* a header with navigation to a home page, a minimal title and an automatic detection of github repo (with link)
+* a footer with a &quot;made with nimib&quot; line and a `Show source` button that shows the full source to create the document.
+* (optional) possibility to create a markdown version of the same document (see this document for an example: [docs/index.nim]({repo}/blob/main/docs/index.nim))
+
+Customization over the default is mostly achieved through nim-mustache or changing
+`NbDoc` and `NbBlock` elements (see below api).
+Currently most of the documentation on customization is given by the examples.
+
+### other templates
+
+* `nbImage`: image command to show images (see `penguins.nim` example linked above)
+* `nbFile`: content (string or untyped) is saved to file (see example document [files]({docs}/files.html))
+* `nbRawOutput`: called with string content, it will add the raw content to document (html backend)
+* `nbTextWithCode`: a variant of `nbText` that also reads nim source. See example of usage
+  at the end of the source in `numerical.nim` linked above.
+* `nbPython`:  can be used after calling `nbInitPython()` and it runs and capture output of python code;
+  requires [nimpy](https://github.com/yglukhov/nimpy).
+
+### creating custom blocks
+
+* `newNbCodeBlock(cmd: string, body, blockImpl: untyped)`: template that can be used to create custom
+  code block that will need both a `body` and an implementation which might make use of `body`.
+  Also, the source code in `body` is read.
+  Example blocks created with `newNbCodeBlock` are `nbCode` and `nbTextWithCode`.
+* `newNbSlimBlock(cmd: string, blockImpl: untyped)`: template that can be used to create
+  a custom block that does not need a separate `body`.
+  Example blocks created with `newNbSlimBlock` are `nbText`, `nbImage` and `nbFile`.
+
+See `src/nimib.nim` for examples on nimib blocks that are built using these two templates.
+
+### interactivity using nim js backend
+
+Nimib can incorporate javascript code generated from nim code using template `nbCodeToJs`.
+It also provides a template `nbKaraxCode` to add code based on [karax](https://github.com/karaxnim/karax).
+
+See [interactivity]({docs}/interactivity.html) for an explanation of the api
+and [counter]({docs}/counters.html) for examples of how to create widgets using it.
+In [caesar]({docs}/caesar.html) we have an example of a karax app
+that implements [Caesar cipher](https://en.wikipedia.org/wiki/Caesar_cipher).
+
+### latex
+
+See [numerical]({docs}/numerical.html) for an example of latex usage.
+
+To add latex support:
+
+  * add a `nb.useLatex` command somewhere between `nbInit` and `nbSave`
+  * use delimiters `$` for inline-math or `$$` for display math inside nbText blocks.
+
+Latex is rendered with [katex](https://katex.org/) through an autodetection during document loading.
+
+### config, command line options and interaction with filesystem
+
+In the default situation a single nimib document
+that writes or reads from filesystem will behave as a normal nim file:
+the current directory is the directory from where you launch the executable.
+
+When nimib is used to produce a website or in general a collection of document
+it is useful to set up a **configuration file**.
+A nimib configuration file is a file named `nimib.toml` and
+it is a [toml](https://github.com/toml-lang/toml) file.
+Every time `nbInit` is called nimib tries to find a config file in current directory
+or in any parent directory.
+Inside a config file you can define two special directory:
+
+* `homeDir`: the directory to set as current directory.
+  It can be given as an absolute directory or as a relative directory.
+  When it is given as a relative directory it is relative with respect
+  to the directory of config file.
+* `srcDir`: the directory where all the sources resides.
+  It is used to create the output filename that includes a relative path.
+  In this way the folder structure of nim files can be recreated in the output.
+  As `homeDir`, it can be set as absolute or relative (to config).
+
+`nbInit` also parses command line options that start with `nb` or `nimib`
+that allow to override the above value, skip the config file or other options.
+
+All the options available can be seen by running any nimib file with option `nbHelp`
+(execution will stop after `nbInit`).
+&quot;&quot;&quot;</span>.emojize
+
+nbCode:
+  <span class="hljs-keyword">import</span> osproc
+  withDir nb.srcDir:
+    <span class="hljs-keyword">echo</span> execProcess(<span class="hljs-string">&quot;nim r --verbosity:0 --hints:off --warning:UnusedImport:off hello --nbHelp&quot;</span>)
+
+nbText: <span class="hljs-string">hlMdF&quot;&quot;&quot;
+
+The value of options are available in `nb.options` field which also
+tracks further options in `nb.options.other: seq[tuple[kind: CmdLineKind; name, value: string]]`.
+
+### Code capture
+
+The code capture of a block like `nbCode` (or other custom blocks)
+can happen in two different ways:
+
+* `CodeAsInSource` (default since version 0.3): code for a single block
+  is parsed from file source (available in `nb.source`).
+* `CodeFromAst` (default in versions 0.1 and 0.2): code for a single block
+  is rendered from AST of body. This means that only documentation comments
+  are shown (since normal comments are not part of the AST) and that the source show
+  might be different from original source.
+  Since version 0.3 this is available through compile time switch `nimibCodeFromAst`.
+
+## :honeybee: API &lt;!-- Api means bees in Italian --&gt;
+
+* `nbInit` template creates and injects a `nb` variable of type `NbDoc`.
+* templates like `nbCode` and `nbText` create a new object of type `NbBlock`,
+  these objects are added to a sequence of blocks accessible in `nb.blocks`
+* the last processed block is available as `nb.blk`
+* `nb.blk.output` contains the (non rendered) output of block
+* `nb.blk.code` contains the source code of the block
+* Work is ongoing to have the code source exactly as in source file (see PR ([#63](https://github.com/pietroppeter/nimib/pull/63)))
+* `NbBlock` is a ref object, so changing `nb.blk`, changes the last block in `nb.blocks`.
+* rendering happens during the call of `nbSave` and and calls a `nb.render` proc
+  that can be overriden
+* two render procs are available in nimib, one to produce a html, one to produce markdown
+* the default html render proc uses [nim-mustache](https://github.com/soasme/nim-mustache)
+  to produce the final document starting from a `document` template available in memory
+* the main template (`document`) or all the other templates can be ovveriden in memory or
+  providing an ovveride in a template directory
+  (defaults are `.` and `templates`, can be overriden with `nb.templateDirs`)
+* the templates in memory are available as `nb.partials`
+  (partial is another name for a mustache template)
+* to fill in all details, mustache starts from a `Context` object, that is initialized during `nbInit`
+  and can be updated later (accessible as `nb.context`)
+* during `nbInit` a default theme is called that initializes all partials and the context.
+  this process can be overriden to create a new &quot;theme&quot; for nimib
+  (see for example [nimibook](https://github.com/pietroppeter/nimibook))
+
+Here are two examples that show how to hijack the api:
+
+* [nolan]({docs}/nolan.html): how to mess up the timeline of blocks :hourglass_flowing_sand:
+* [pythno]({docs}/pythno.html): a reminder that nim is not python :stuck_out_tongue_winking_eye:
+
+## Changelog and :pray: Thanks
+
+In the [changelog](changelog.md) you find all recent changes, some early history of nimib, pointers to relevant
+examples of usage of nimib and heartfelt thanks to some of the fine folks that
+made this development possible.
+
+## :sunrise: Roadmap
+
+- add more themes such as [nimibook](https://github.com/pietroppeter/nimibook).
+  In particular themes for blogging and for creating general websites.
+- can I use nimib to build a library directly from documentation (like in [nbdev](https://github.com/fastai/nbdev))?
+- nimib executable for scaffolding and to support different publishing workflows
+- server-side dynamic sites (streamlit style? take advantage of caching instead of hot code reloading)
+- possibility of editing document in the browser (similar to jupyter UI, not necessarily taking advantage of hot code reloading)
+- ...
+
+completed in 0.3:
+- [x] refactor rendering of blocks and simplify api extensions ([#24](https://github.com/pietroppeter/nimib/issues/24))
+- [x] client-side dynamic site: interactivity of documents, e.g. a dahsboard (possibly taking advantage of nim js backend)
+
+## :question: :exclamation: Q &amp; A
+
+### why the name?
+
+corruption of [ninib](https://www.vocabulary.com/dictionary/Ninib):
+
+&gt; a solar deity; firstborn of Bel and consort was Gula;
+&gt; god of war and the _chase_ and agriculture; sometimes identified with biblical *Nimrod*
+
+also:
+
+&gt; He explains that the seven directions were interpreted by the Babylonian theologians
+&gt; as a reference to the seven great celestial bodies, the sun and moon, Ishtar, Marduk, Ninib, Nergal and Nabu.
+&gt;
+&gt; This process, which reached its culmination in the post-Khammurabic period, led to identifying
+&gt; the planet Jupiter with Marduk, Venus with Ishtar, Mars with Nergal, Mercury with Nebo, and Saturn with Ninib.
+
+and I should not need to tell you what [Marduk](https://jupyter.org/) is
+and why [Saturn is the best planet](https://www.theatlantic.com/science/archive/2016/01/a-major-correction/422514/).
+
+### why the whale :whale:?
+
+why do you need a logo when you have emojis?
+
+no particular meaning about the whale apart the fact that I like the emoji and this project is something I have been [chasing](https://en.wikipedia.org/wiki/Captain_Ahab) for a while
+(and I expect to be chasing it indefinitely).
+
+also googling `nimib whale` you might discover the existence of a cool place: [Skeleton Coast](https://en.wikipedia.org/wiki/Skeleton_Coast).
+
+### why the emojis?
+
+because I made a [package](https://github.com/pietroppeter/nimoji) for that and someone has to use it
+
+### why the Q &amp; A?
+
+because [someone made it into an art form](https://github.com/oakes/vim_cubed#q--a)
+and they tell me [imitation is the sincerest form of flattery](https://www.goodreads.com/quotes/558084-imitation-is-the-sincerest-form-of-flattery-that-mediocrity-can)
+&quot;&quot;&quot;</span>.emojize
+
+<span class="hljs-keyword">when</span> <span class="hljs-keyword">defined</span>(mdOutput):
+  nb.filename = <span class="hljs-string">&quot;../README.md&quot;</span>
+  nbSave
+<span class="hljs-keyword">else</span>:
+  nbSave
+</code></pre>
+</section><script>
+function toggleSourceDisplay() {
+  var btn = document.getElementById("show")
+  var source = document.getElementById("source");
+  if (btn.innerHTML=="Show Source") {
+    btn.innerHTML = "Hide Source";
+    source.style.display = "block";
+  } else {
+    btn.innerHTML = "Show Source";
+    source.style.display = "none";
+  }
+}
+</script></body>
+</html>

--- a/README.md
+++ b/README.md
@@ -1,44 +1,4 @@
-<!DOCTYPE html>
-<html lang="en-us">
-<head>
-  <title>Nimib Docs</title>
-  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2280%22>🐳</text></svg>">
-  <meta content="text/html; charset=utf-8" http-equiv="content-type">
-  <meta content="width=device-width, initial-scale=1" name="viewport">
-  <link rel='stylesheet' href='https://unpkg.com/normalize.css/'>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/kognise/water.css@latest/dist/light.min.css">
-  <link rel='stylesheet' href='https://cdn.jsdelivr.net/gh/pietroppeter/nimib/assets/atom-one-light.css'>
-  <style>
-.nb-box {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-.nb-small {
-  font-size: 0.8rem;
-}
-button.nb-small {
-  float: right;
-  padding: 2px;
-  padding-right: 5px;
-  padding-left: 5px;
-}
-section#source {
-  display:none
-}
-</style>
-  
-  <script async defer data-domain="pietroppeter.github.io/nimib" src="https://plausible.io/js/plausible.js"></script>
-</head>
-<body>
-<header>
-<div class="nb-box">
-  <span><a href=".">🏡</a></span>
-  <span><code>index.nim</code></span>
-  <span><a href="https://github.com/pietroppeter/nimib"><svg aria-hidden="true" width="1.2em" height="1.2em" style="vertical-align: middle;" preserveAspectRatio="xMidYMid meet" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59c.4.07.55-.17.55-.38c0-.19-.01-.82-.01-1.49c-2.01.37-2.53-.49-2.69-.94c-.09-.23-.48-.94-.82-1.13c-.28-.15-.68-.52-.01-.53c.63-.01 1.08.58 1.23.82c.72 1.21 1.87.87 2.33.66c.07-.52.28-.87.51-1.07c-1.78-.2-3.64-.89-3.64-3.95c0-.87.31-1.59.82-2.15c-.08-.2-.36-1.02.08-2.12c0 0 .67-.21 2.2.82c.64-.18 1.32-.27 2-.27c.68 0 1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82c.44 1.1.16 1.92.08 2.12c.51.56.82 1.27.82 2.15c0 3.07-1.87 3.75-3.65 3.95c.29.25.54.73.54 1.48c0 1.07-.01 1.93-.01 2.2c0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z" fill="#000"></path></svg></a></span>
-</div>
-<hr>
-</header><main>
+
 # nimib 🐳 - nim 👑 driven ⛵ publishing ✍
 
 Nimib provides an API to convert your Nim code and its outputs to html documents.
@@ -88,9 +48,13 @@ First have a look at the following html document: [hello.html](./hello.html)
 
 This was produced with `nim r docs/hello`, where [docs/hello.nim](https://github.com/pietroppeter/nimib/blob/main/docs/hello.nim) is:
 
+
+
 ```nim
 discard
 ```
+
+
 
 
 ### Other examples of usage
@@ -218,10 +182,12 @@ that allow to override the above value, skip the config file or other options.
 All the options available can be seen by running any nimib file with option `nbHelp`
 (execution will stop after `nbInit`).
 
+
+
 ```nim
 import osproc
 withDir nb.srcDir:
-  echo execProcess(&quot;nim r --verbosity:0 --hints:off --warning:UnusedImport:off hello --nbHelp&quot;)
+  echo execProcess(&quot;nim r --verbosity:0 --hints:off hello --nbHelp&quot;)
 ```
 
 
@@ -236,6 +202,8 @@ Nimib options:
   --nbFilename, --nimibFilename             overrides name of output file (e.g. somefile --nbFilename:othername.html)
   --nbShow,     --nimibShow                 open in browser at the end of nbSave
 ```
+
+
 
 
 
@@ -343,351 +311,4 @@ because I made a [package](https://github.com/pietroppeter/nimoji) for that and 
 
 because [someone made it into an art form](https://github.com/oakes/vim_cubed#q--a)
 and they tell me [imitation is the sincerest form of flattery](https://www.goodreads.com/quotes/558084-imitation-is-the-sincerest-form-of-flattery-that-mediocrity-can)
-</main>
-<footer>
-<hr>
-<div class="nb-box">
-  <span><span class="nb-small">made with <a href="https://pietroppeter.github.io/nimib/">nimib 🐳</a></span></span>
-  <span></span>
-  <span><button class="nb-small" id="show" onclick="toggleSourceDisplay()">Show Source</button></span>
-</div>
-</footer>
-<section id="source">
-<pre><code class="nim hljs"><span class="hljs-keyword">import</span> nimib, strformat, nimoji, nimib / renders
 
-<span class="hljs-keyword">when</span> <span class="hljs-keyword">defined</span>(mdOutput):
-  nbInit(backend=useMdBackend)
-<span class="hljs-keyword">else</span>:
-  nbInit
-nb.title = <span class="hljs-string">&quot;Nimib Docs&quot;</span>
-
-<span class="hljs-keyword">let</span>
-  repo = <span class="hljs-string">&quot;https://github.com/pietroppeter/nimib&quot;</span>
-  docs = <span class="hljs-keyword">if</span> <span class="hljs-keyword">defined</span>(useMdBackend): <span class="hljs-string">&quot;https://pietroppeter.github.io/nimib&quot;</span> <span class="hljs-keyword">else</span>: <span class="hljs-string">&quot;.&quot;</span>
-  hello = read(nb.srcDir / <span class="hljs-string">&quot;hello.nim&quot;</span>.<span class="hljs-type">RelativeFile</span>)
-  assets = <span class="hljs-string">&quot;docs/static&quot;</span>
-  highlight = <span class="hljs-string">&quot;highlight.nim.js&quot;</span>
-  defaultHighlightCss = <span class="hljs-string">&quot;atom-one-light.css&quot;</span>
-
-nbText: <span class="hljs-string">hlMdF&quot;&quot;&quot;
-# nimib :whale: - nim :crown: driven :sailboat: publishing :writingHand:
-
-Nimib provides an API to convert your Nim code and its outputs to html documents.
-
-The type of html output that is obtained by default is similar to html notebooks produced by tools
-like [Jupyter](https://nbviewer.jupyter.org/url/norvig.com/ipython/Advent%20of%20Code.ipynb)
-or [RMarkdown](https://rmarkdown.rstudio.com/lesson-10.html), but nimib provides this starting
-directly from standard nim files. It currently does not provide any type of interactivity or automatic reloading.
-
-If you have some nim code lying around that echoes stuff you can try how nimib works with following these steps:
-  * run in shell `nimble install nimib`
-  * add `import nimib` at the top of your nim file
-  * add a `nbInit` command right after that
-  * split your code into one or more `nbCode:` blocks
-  * add some text commentary in markdown through `nbText:` blocks
-  * add a `nbSave` command at the end
-  * compile and run
-  * open the html file that has been generated next to your nim file (same name)
-  * (you can use runtime option `--nbShow` to open the html file automatically in your default browser)
-
-See below for an example of this.
-
-Nimib strives for:
-  * a simple API
-  * sane defaults
-  * easy customization
-
-The main goal of Nimib is to empower people to explore nim and its ecosystem and share with others.
-
-This document is generated though nimib both as an index.html file and as a README.md,
-you should be reading one of the two, for the other:
-
-* [README.md]({repo})
-* [index.html]({docs})
-
-Nimib was presented in [NimConf2021](https://conf.nim-lang.org),
-see [video](https://www.youtube.com/watch?v=sWA58Wtk6L8)
-and [slides](https://github.com/pietroppeter/nimconf2021). 
-
-The vs code extension
-[nimiboost](https://marketplace.visualstudio.com/items?itemName=hugogranstrom.nimiboost)
-provides markdown highlighting in nimib file and a preview mechanism.
-
-## :wave: :earthAfrica: Example Usage
-
-First have a look at the following html document: [hello.html]({docs}/hello.html)
-
-This was produced with `nim r docs/hello`, where [docs/hello.nim]({repo}/blob/main/docs/hello.nim) is:
-&quot;&quot;&quot;</span>.emojize
-
-
-<span class="hljs-keyword">when</span> <span class="hljs-keyword">not</span> <span class="hljs-keyword">defined</span>(useMdBackend):
-  nbCode: <span class="hljs-keyword">discard</span>
-  nb.blk.code = hello  <span class="hljs-comment"># &quot;\n&quot; should not be needed here (fix required in rendering)</span>
-<span class="hljs-keyword">else</span>:
-  nbText &amp;<span class="hljs-string">&quot;&quot;&quot;
-```nim
-{hello}
-```&quot;&quot;&quot;</span>
-
-
-nbText: <span class="hljs-string">hlMdF&quot;&quot;&quot;
-### Other examples of usage
-
-in this repo:
-
-* [index]({docs}/index.html): generate an HTML and a README.md at the same time (you are reading one of the two)
-* [penguins]({docs}/penguins.html): explore palmer penguins dataset using ggplotnim (example of showing images)
-* [numerical]({docs}/numerical.html): example usage of NumericalNim (example of custom style, usage of latex)
-* [cheatsheet]({docs}/cheatsheet.html): markdown cheatsheet (example of a custom block, custom highlighting and a simple TOC)
-* [mostaccio]({docs}/mostaccio.html): examples of usage of nim-mustache and of dark mode.
-* [interactivity]({docs}/interactivity.html): shows the basic API of creating interactive elements using `nbCodeToJs`.
-* [counter]({docs}/counters.html): shows how to create reusable interactive widgets by creating a counter button.
-* [caesar]({docs}/caesar.html): a Caesar cipher implemented using `nbCodeToJs` and `karax`.
-
-
-elsewhere:
-
-* [adventofnim](https://pietroppeter.github.io/adventofnim/index.html): solutions for advent of code in nim
-* [intro to binarylang](https://ajusa.github.io/binarylang-fun/intro.html): a introduction to library [binarylang](https://github.com/sealmove/binarylang) (first public usage of nimib I was aware of)
-* [nblog](https://github.com/pietroppeter/nblog): a blog about nimib and its ecosystem
-* [nimibook](https://github.com/pietroppeter/nimibook): a port of mdbook to nim(ib)
-* [SciNim Getting Started](https://scinim.github.io/getting-started/): tutorials for nim in scientific computing 
-* [Norm documentation](https://norm.nim.town): documentation of a Nim ORM library.
-* [NimiSlides](https://github.com/HugoGranstrom/nimib-reveal): a [reveal.js](https://revealjs.com) theme for nimib.
-
-you are welcome to add here what you have built with nimib!
-
-## :hammer_and_wrench: Features
-
-&gt; “I try all things, I achieve what I can.” ― Herman Melville, Moby-Dick or, the Whale
-
-The following are the main elements of a default nimib document:
-
-* `nbInit`: initializes a nimib document, required for all other commands to work.
-  In particular it creates and injects into scope a `nb` object used by all other blocks
-  (see below section API for internal details).
-* `nbCode`: code blocks with automatic stdout capture and capture of code source
-* `nbText`: text blocks with automatic conversion from markdown to html (thanks to [nim-markdown](https://github.com/soasme/nim-markdown))
-* `nbSave`: save the document (by default to html)
-* styling with [water.css](https://watercss.kognise.dev/), light mode is default, dark mode available (`nb.darkMode` after `nbInit`).
-* static highlighting of nim code. Highlight styling classes are the same of [highlightjs](https://highlightjs.org/)
-  and you can pick a different styling (`atom-one-light` is default for light mode, `androidstudio` is default for dark mode).
-* (optional) latex rendering through [katex](https://katex.org/) (see below)
-* a header with navigation to a home page, a minimal title and an automatic detection of github repo (with link)
-* a footer with a &quot;made with nimib&quot; line and a `Show source` button that shows the full source to create the document.
-* (optional) possibility to create a markdown version of the same document (see this document for an example: [docs/index.nim]({repo}/blob/main/docs/index.nim))
-
-Customization over the default is mostly achieved through nim-mustache or changing
-`NbDoc` and `NbBlock` elements (see below api).
-Currently most of the documentation on customization is given by the examples.
-
-### other templates
-
-* `nbImage`: image command to show images (see `penguins.nim` example linked above)
-* `nbFile`: content (string or untyped) is saved to file (see example document [files]({docs}/files.html))
-* `nbRawOutput`: called with string content, it will add the raw content to document (html backend)
-* `nbTextWithCode`: a variant of `nbText` that also reads nim source. See example of usage
-  at the end of the source in `numerical.nim` linked above.
-* `nbPython`:  can be used after calling `nbInitPython()` and it runs and capture output of python code;
-  requires [nimpy](https://github.com/yglukhov/nimpy).
-* `nbClearOutput`: clears the output of preceding code block,
-  useful in case a previous command has produced output that you do not want to show for some reason.
-
-
-### creating custom blocks
-
-* `newNbCodeBlock(cmd: string, body, blockImpl: untyped)`: template that can be used to create custom
-  code block that will need both a `body` and an implementation which might make use of `body`.
-  Also, the source code in `body` is read.
-  Example blocks created with `newNbCodeBlock` are `nbCode` and `nbTextWithCode`.
-* `newNbSlimBlock(cmd: string, blockImpl: untyped)`: template that can be used to create
-  a custom block that does not need a separate `body`.
-  Example blocks created with `newNbSlimBlock` are `nbText`, `nbImage` and `nbFile`.
-
-See `src/nimib.nim` for examples on nimib blocks that are built using these two templates.
-
-### interactivity using nim js backend
-
-Nimib can incorporate javascript code generated from nim code using template `nbCodeToJs`.
-It also provides a template `nbKaraxCode` to add code based on [karax](https://github.com/karaxnim/karax).
-
-See [interactivity]({docs}/interactivity.html) for an explanation of the api
-and [counter]({docs}/counters.html) for examples of how to create widgets using it.
-In [caesar]({docs}/caesar.html) we have an example of a karax app
-that implements [Caesar cipher](https://en.wikipedia.org/wiki/Caesar_cipher).
-
-### latex
-
-See [numerical]({docs}/numerical.html) for an example of latex usage.
-
-To add latex support:
-
-  * add a `nb.useLatex` command somewhere between `nbInit` and `nbSave`
-  * use delimiters `$` for inline-math or `$$` for display math inside nbText blocks.
-
-Latex is rendered with [katex](https://katex.org/) through an autodetection during document loading.
-
-### config, command line options and interaction with filesystem
-
-In the default situation a single nimib document
-that writes or reads from filesystem will behave as a normal nim file:
-the current directory is the directory from where you launch the executable.
-
-When nimib is used to produce a website or in general a collection of document
-it is useful to set up a **configuration file**.
-A nimib configuration file is a file named `nimib.toml` and
-it is a [toml](https://github.com/toml-lang/toml) file.
-Every time `nbInit` is called nimib tries to find a config file in current directory
-or in any parent directory.
-Inside a config file you can define two special directory:
-
-* `homeDir`: the directory to set as current directory.
-  It can be given as an absolute directory or as a relative directory.
-  When it is given as a relative directory it is relative with respect
-  to the directory of config file.
-* `srcDir`: the directory where all the sources resides.
-  It is used to create the output filename that includes a relative path.
-  In this way the folder structure of nim files can be recreated in the output.
-  As `homeDir`, it can be set as absolute or relative (to config).
-
-`nbInit` also parses command line options that start with `nb` or `nimib`
-that allow to override the above value, skip the config file or other options.
-
-All the options available can be seen by running any nimib file with option `nbHelp`
-(execution will stop after `nbInit`).
-&quot;&quot;&quot;</span>.emojize
-
-nbCode:
-  <span class="hljs-keyword">import</span> osproc
-  withDir nb.srcDir:
-    <span class="hljs-keyword">echo</span> execProcess(<span class="hljs-string">&quot;nim r --verbosity:0 --hints:off --warning:UnusedImport:off hello --nbHelp&quot;</span>)
-
-nbText: <span class="hljs-string">hlMdF&quot;&quot;&quot;
-
-The value of options are available in `nb.options` field which also
-tracks further options in `nb.options.other: seq[tuple[kind: CmdLineKind; name, value: string]]`.
-
-### Code capture
-
-The code capture of a block like `nbCode` (or other custom blocks)
-can happen in two different ways:
-
-* `CodeAsInSource` (default since version 0.3): code for a single block
-  is parsed from file source (available in `nb.source`).
-* `CodeFromAst` (default in versions 0.1 and 0.2): code for a single block
-  is rendered from AST of body. This means that only documentation comments
-  are shown (since normal comments are not part of the AST) and that the source show
-  might be different from original source.
-  Since version 0.3 this is available through compile time switch `nimibCodeFromAst`.
-
-## :honeybee: API &lt;!-- Api means bees in Italian --&gt;
-
-* `nbInit` template creates and injects a `nb` variable of type `NbDoc`.
-* templates like `nbCode` and `nbText` create a new object of type `NbBlock`,
-  these objects are added to a sequence of blocks accessible in `nb.blocks`
-* the last processed block is available as `nb.blk`
-* `nb.blk.output` contains the (non rendered) output of block
-* `nb.blk.code` contains the source code of the block
-* Work is ongoing to have the code source exactly as in source file (see PR ([#63](https://github.com/pietroppeter/nimib/pull/63)))
-* `NbBlock` is a ref object, so changing `nb.blk`, changes the last block in `nb.blocks`.
-* rendering happens during the call of `nbSave` and and calls a `nb.render` proc
-  that can be overriden
-* two render procs are available in nimib, one to produce a html, one to produce markdown
-* the default html render proc uses [nim-mustache](https://github.com/soasme/nim-mustache)
-  to produce the final document starting from a `document` template available in memory
-* the main template (`document`) or all the other templates can be ovveriden in memory or
-  providing an ovveride in a template directory
-  (defaults are `.` and `templates`, can be overriden with `nb.templateDirs`)
-* the templates in memory are available as `nb.partials`
-  (partial is another name for a mustache template)
-* to fill in all details, mustache starts from a `Context` object, that is initialized during `nbInit`
-  and can be updated later (accessible as `nb.context`)
-* during `nbInit` a default theme is called that initializes all partials and the context.
-  this process can be overriden to create a new &quot;theme&quot; for nimib
-  (see for example [nimibook](https://github.com/pietroppeter/nimibook))
-
-Here are two examples that show how to hijack the api:
-
-* [nolan]({docs}/nolan.html): how to mess up the timeline of blocks :hourglass_flowing_sand:
-* [pythno]({docs}/pythno.html): a reminder that nim is not python :stuck_out_tongue_winking_eye:
-
-## Changelog and :pray: Thanks
-
-In the [changelog](changelog.md) you find all recent changes, some early history of nimib, pointers to relevant
-examples of usage of nimib and heartfelt thanks to some of the fine folks that
-made this development possible.
-
-## :sunrise: Roadmap
-
-- add more themes such as [nimibook](https://github.com/pietroppeter/nimibook).
-  In particular themes for blogging and for creating general websites.
-- can I use nimib to build a library directly from documentation (like in [nbdev](https://github.com/fastai/nbdev))?
-- nimib executable for scaffolding and to support different publishing workflows
-- server-side dynamic sites (streamlit style? take advantage of caching instead of hot code reloading)
-- possibility of editing document in the browser (similar to jupyter UI, not necessarily taking advantage of hot code reloading)
-- ...
-
-completed in 0.3:
-- [x] refactor rendering of blocks and simplify api extensions ([#24](https://github.com/pietroppeter/nimib/issues/24))
-- [x] client-side dynamic site: interactivity of documents, e.g. a dahsboard (possibly taking advantage of nim js backend)
-
-## :question: :exclamation: Q &amp; A
-
-### why the name?
-
-corruption of [ninib](https://www.vocabulary.com/dictionary/Ninib):
-
-&gt; a solar deity; firstborn of Bel and consort was Gula;
-&gt; god of war and the _chase_ and agriculture; sometimes identified with biblical *Nimrod*
-
-also:
-
-&gt; He explains that the seven directions were interpreted by the Babylonian theologians
-&gt; as a reference to the seven great celestial bodies, the sun and moon, Ishtar, Marduk, Ninib, Nergal and Nabu.
-&gt;
-&gt; This process, which reached its culmination in the post-Khammurabic period, led to identifying
-&gt; the planet Jupiter with Marduk, Venus with Ishtar, Mars with Nergal, Mercury with Nebo, and Saturn with Ninib.
-
-and I should not need to tell you what [Marduk](https://jupyter.org/) is
-and why [Saturn is the best planet](https://www.theatlantic.com/science/archive/2016/01/a-major-correction/422514/).
-
-### why the whale :whale:?
-
-why do you need a logo when you have emojis?
-
-no particular meaning about the whale apart the fact that I like the emoji and this project is something I have been [chasing](https://en.wikipedia.org/wiki/Captain_Ahab) for a while
-(and I expect to be chasing it indefinitely).
-
-also googling `nimib whale` you might discover the existence of a cool place: [Skeleton Coast](https://en.wikipedia.org/wiki/Skeleton_Coast).
-
-### why the emojis?
-
-because I made a [package](https://github.com/pietroppeter/nimoji) for that and someone has to use it
-
-### why the Q &amp; A?
-
-because [someone made it into an art form](https://github.com/oakes/vim_cubed#q--a)
-and they tell me [imitation is the sincerest form of flattery](https://www.goodreads.com/quotes/558084-imitation-is-the-sincerest-form-of-flattery-that-mediocrity-can)
-&quot;&quot;&quot;</span>.emojize
-
-<span class="hljs-keyword">when</span> <span class="hljs-keyword">defined</span>(mdOutput):
-  nb.filename = <span class="hljs-string">&quot;../README.md&quot;</span>
-  nbSave
-<span class="hljs-keyword">else</span>:
-  nbSave
-</code></pre>
-</section><script>
-function toggleSourceDisplay() {
-  var btn = document.getElementById("show")
-  var source = document.getElementById("source");
-  if (btn.innerHTML=="Show Source") {
-    btn.innerHTML = "Hide Source";
-    source.style.display = "block";
-  } else {
-    btn.innerHTML = "Show Source";
-    source.style.display = "none";
-  }
-}
-</script></body>
-</html>

--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ Currently most of the documentation on customization is given by the examples.
   at the end of the source in `numerical.nim` linked above.
 * `nbPython`:  can be used after calling `nbInitPython()` and it runs and capture output of python code;
   requires [nimpy](https://github.com/yglukhov/nimpy).
+* `nbClearOutput`: clears the output of preceding code block,
+  useful in case a previous command has produced output that you do not want to show for some reason.
+
 
 ### creating custom blocks
 
@@ -488,6 +491,9 @@ Currently most of the documentation on customization is given by the examples.
   at the end of the source in `numerical.nim` linked above.
 * `nbPython`:  can be used after calling `nbInitPython()` and it runs and capture output of python code;
   requires [nimpy](https://github.com/yglukhov/nimpy).
+* `nbClearOutput`: clears the output of preceding code block,
+  useful in case a previous command has produced output that you do not want to show for some reason.
+
 
 ### creating custom blocks
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ Currently most of the documentation on customization is given by the examples.
 
 See `src/nimib.nim` for examples on nimib blocks that are built using these two templates.
 
+* a `newId` proc is available for `nb: NbDoc` object and provides an incremental integer.
+  It can be used in some custom blocks (it is used in `nbCodeToJs` described below).
+
 ### interactivity using nim js backend
 
 Nimib can incorporate javascript code generated from nim code using template `nbCodeToJs`.
@@ -230,29 +233,37 @@ can happen in two different ways:
   these objects are added to a sequence of blocks accessible in `nb.blocks`
 * the last processed block is available as `nb.blk`
 * `nb.blk.output` contains the (non rendered) output of block
-* `nb.blk.code` contains the source code of the block
-* Work is ongoing to have the code source exactly as in source file (see PR ([#63](https://github.com/pietroppeter/nimib/pull/63)))
+* `nb.blk.code` contains the source code of the block (if it was created with `newNbCodeBlock`)
 * `NbBlock` is a ref object, so changing `nb.blk`, changes the last block in `nb.blocks`.
-* rendering happens during the call of `nbSave` and and calls a `nb.render` proc
-  that can be overriden
-* two render procs are available in nimib, one to produce a html, one to produce markdown
-* the default html render proc uses [nim-mustache](https://github.com/soasme/nim-mustache)
-  to produce the final document starting from a `document` template available in memory
-* the main template (`document`) or all the other templates can be ovveriden in memory or
-  providing an ovveride in a template directory
-  (defaults are `.` and `templates`, can be overriden with `nb.templateDirs`)
-* the templates in memory are available as `nb.partials`
-  (partial is another name for a mustache template)
-* to fill in all details, mustache starts from a `Context` object, that is initialized during `nbInit`
-  and can be updated later (accessible as `nb.context`)
-* during `nbInit` a default theme is called that initializes all partials and the context.
-  this process can be overriden to create a new "theme" for nimib
-  (see for example [nimibook](https://github.com/pietroppeter/nimibook))
 
 Here are two examples that show how to hijack the api:
 
 * [nolan](./nolan.html): how to mess up the timeline of blocks ⏳
 * [pythno](./pythno.html): a reminder that nim is not python 😜
+
+## Rendering
+
+* rendering is currently based on [nim-mustache](https://github.com/soasme/nim-mustache).
+  This will likely be changed in a next release and in fact refactoring the rendering part of nimib
+  is the main target for next breaking change, see [#111](https://github.com/pietroppeter/nimib/issues/111)
+* there are two rendering backends, a html one and a markdown backend.
+  In order to use the markdown backend one must initialize its document with `nbInitMd` instead of `nbInit`
+* rendering happens during the call to `nbSave`, and two steps are performed:
+  1. rendering all blocks and adding them to a sequence of blocks (added to `nb.context["blocks"]`)
+  2. rendering the document starting from `document` partial using 
+* rendering of a single block depends
+  on a number of fields of `nb` object:
+  - `partials`: a `Table[string, string]` that contains the templates/partials for every command (e.g. `nb.partials["nbCode"]`);
+  - `templateDirs`: a `seq[string]` of folders where to look for `.mustache` templates that can complement/override
+    the templates in `partials`.
+    A common usage is to add a `head_other.mustache` template that contain additional content added to head section 
+    of **every** document (in many repositories - including nimib - it is used to add a [plausible analytics](https://plausible.io) script)
+  - `renderPlans`: a `Table[string, seq[string]]` that contains the render plan (a `seq[string]`) for every step of render plan
+    an associated `renderProc` is called;
+  - `renderProcs`: a `Table[string, NbRenderProc]` that contains all available render procs by name.
+     (`type NbRenderProc = proc (doc: var NbDoc, blk: var NbBlock) {. nimcall .}`)
+* the above fields are initialized during `nbInit` with a call to `render` backend and can
+  be customized by a call to `theme` (`render` and `theme` have default values).
 
 ## Changelog and 🙏 Thanks
 

--- a/changelog.md
+++ b/changelog.md
@@ -19,7 +19,8 @@ and further adjustments were made along the way (#80, #81).
 Some new blocks are introduced taking advantage of this (e.g. `nbRawOutput`, `nbPython`) (#80, #83).
 
 Contributing to the codebase is made easier through introduction of proper testing (#80)
-and deploy previews (#89, #90, #91, #92, #93). Documentation has been updated to include all changes so far
+docs are now built in CI (#89, #90, #91) and deploy previews have been added (#92, #93).
+Documentation has been updated to include all changes so far
 and contextually the changelog has been updated (#103).
 
 A big milestone is reached (#88) by introducing templates to add interactivity to documents
@@ -70,6 +71,27 @@ List of detailed changes:
 * untyped version of `nbFile` removed, new example document `files.nim`, changed the rendering of `nbFile`
   (no more "writing file ..." only the name of file is added) (#81)
 * added `loadNimibCfg` proc that can be used for themes (used by nimibook) (#81)
+* added `nbInitPython` and `nbPython` templates to support running python in nimib documents using `nimpy` (#83)
+  - `md` and `fmd` from `nimib / boost` now deprecated and replaced by `hlMd` and `hlMdF`
+  - new `hlPy` and `hlPyF` in `nimib / boost`
+* docs now are built in CI (#89, #90, #91)
+  - sources of docs are now in folder `docsrc`
+  - outputs are in `docs`
+* add deploy preview through netlify (#92, #93)
+* new templates to introduce interactivity in documents taking advantage of nim's javascript backend (#88)
+  - `nbCodeToJs`: a block of nim code is compiled to javascript and added as a script to html file (and allows capturing of variables)
+  - `nbCodeToJsInit`, `addCodeToJs`, `addToDocAsJs`: templates to allow splitting in multiple blocks the code in `nbCodeToJs`
+  - `nbCodeToJsShowSource`: template to show the nim source of a `nbCodeToJs` block.
+  - `nbKaraxCode` (with `karaxHtml`): template to create a karax app/widget with minimal boilerplate (based on `nbCodeToJs`)
+  - new example document `interactivity.nim`: explains the basic of `nbCodeToJs` and related templates
+  - new example document `counters.nim`: shows how to create counter widgets using `nbCodeToJs`
+  - new example document `caesar.nim`: a caesar cipher app built using `nbKaraxCode`
+  - new module `nimib / jsutils` to support the implementation of the above 
+* `newId` proc for `NbDoc` that gives a new incremental integer every time it is called (#88)
+* `CodeAsInSource` is made default:
+  - new `nimibCodeFromAst` flag to revert to old default
+  - added a warning to `nimibPreviewCodeAsInSource` (now obsolete)
+* various fixes to `CodeAsInSource` (#105, #106, #108)
 
 Thanks to @metagn for improving our CI/nimble file! Every contribution counts!
 

--- a/changelog.md
+++ b/changelog.md
@@ -94,8 +94,10 @@ List of detailed changes:
 * various fixes to `CodeAsInSource` (#105, #106, #108)
 * changelog updated and separated from documentation (#103)
 * updated documentation to include most recent changes (#103)
-* fix md output of `index.nim` (#103)
 * turned off warning for unused imports in `nimib.nim` (#103)
+* fix markdown backend, it was broken since html theme was overiding render backend (#103):
+  - new `nbInitMd` to use markdown backend
+  - new `themes.noTheme` for empty theme (used by `nbInitMd`)
 
 Thanks to @metagn for improving our CI/nimble file! Every contribution counts!
 

--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,57 @@ When contributing a fix, feature or example please add a new line to briefly exp
 
 * _insert here next change_
 
-## 0.3
+## 0.3 "Block Maker" (July 2022)
+
+This release started with the aim of making the construction of custom blocks as easy as the construction of native blocks.
+A wide refactoring of the codebase was required for this (#78)
+and further adjustments were made along the way (#80, #81).
+Some new blocks are introduced taking advantage of this (e.g. `nbRawOutput`, `nbPython`) (#80, #83).
+
+Contributing to the codebase is made easier through introduction of proper testing (#80)
+and deploy previews (#89, #90, #91, #92, #93). Documentation has been updated to include all changes so far
+and contextually the changelog has been updated (#103).
+
+A big milestone is reached (#88) by introducing templates to add interactivity to documents
+taking advantage of nim js backend (`nbCodeToJs` allows to incorporate javascript scripts in the document derived from nim code).
+In particular templates to reduce boilerplate when developing karax based apps or
+widgets are introduced (`nbKaraxCode`, `karaxHtml`).
+Three new example documents are introduced for documenting this change (`interactivity`, `counters`, `caesar`).
+
+Another major change is setting as default the `CodeAsInSource` introduced in 0.2.4
+(a number of fixes are made: #105, #106, #108).
+
+Most of these contributions are due to @HugoGranstrom
+(thanks for all the awesome work on this ❤️) which joins @pietroppeter
+as maintainer and co-creator of nimib! 🥳
+
+List of detailed changes:
+
+* refactoring of `NbBlock` type and rendering of blocks (#80):
+  * `NbBlock` type is completely refactored. Instead of having a `kind` with a fixed
+    number of values, a block behaviour is specified by a `command` string
+    which is set to the name of the command template used to create a block
+    (e.g. `nbCode`, `nbText`, `nbImage`, ...) - 
+  * Every block now has a `context` field and the rendering backend (either html or markdown)
+    has a mechanism to retrieve a `partial` for every command.
+  * as an additional mechanism to be able to perform other computations when rendering,
+    a sequence of `renderProc`s can be assigned for every command (for a specific backend).
+  * some other accidental or not so welcome changes that happened during the refactoring:
+    - `sugar` is now exported _(accidental)_
+    - `nb: NbDoc` is mutated when rendered _(unwelcome, will be changed later)_
+    - cannot use both Html and Md backend at the same time _(unwelcome, will be changed later)_
+* fixed cheatsheet document (fixed #52)
+* ptest document is removed (#80)
+
+Thanks to @metagn for improving our CI/nimble file! Every contribution counts!
+
+Relevant examples of usage:
+
+* [nimislides](https://github.com/HugoGranstrom/nimib-reveal): a new nimib theme that allows to create
+  slides using [reveal.js](https://revealjs.com) html presentation framework
+* some posts in nblog are relevant example of new blocks and customization of nimib:
+  - [Making Diagrams using mermaid.js](https://pietroppeter.github.io/nblog/drafts/mermaid_diagram.html)
+  - [Plotly in nimib](https://pietroppeter.github.io/nblog/drafts/show_plotly.html)
 
 ## 0.2.x (November 2021)
 
@@ -19,6 +69,7 @@ When contributing a fix, feature or example please add a new line to briefly exp
 
 * Update penguins example which now uses datamancer and shows Simpson's paradaox, by by @Vindaar (#70)
 * code as in source for nbCode (`-d:nimibPreviewCodeAsInSource`) by @HugoGranstrom (#63): with this option the code shown is not derived from Ast but it is read from source code.
+* ptest document is turned off from CI
 
 ### 0.2.3
 
@@ -53,7 +104,7 @@ relevant external example:
 
 * [norm](https://norm.nim.town) starts to use nimibook for its documentation
 
-Special thanks again to to @Vindaar, @Clonkk and @HugoGranstrom
+Special thanks again to to @Vindaar, @Clonkk and @HugoGranstrom for this release.
 
 ## 0.1.x (March-June 2021)
 
@@ -83,6 +134,8 @@ changes:
 Thanks for this release series to @Vindaar, @Clonkk and @HugoGranstrom who decided to adopt
 nimib in scinim/getting-started and motivated and directly contributed to nimib and nimibook development
 to support this use case.
+
+At the end June 2021, nimib was presented at [NimConf2021](https://conf.nim-lang.org).
 
 ## 0.1 (March 2021)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,116 @@
+
+# Changelog
+
+The changelog includes a bit of the early history of nimib, pointers to relevant
+examples of usage of nimib and heartfelt thanks to some of the fine folks that
+made this development possible.
+
+When contributing a fix, feature or example please add a new line to briefly explain the changes. It will be used as release documentation here: https://github.com/pietroppeter/nimib/releases
+
+## 0.3.x
+
+* _insert here next change_
+
+## 0.3
+
+## 0.2.x
+
+### 0.2.4
+
+### 0.2.3
+
+### 0.2.2
+
+### 0.2.1
+
+## 0.2 "Theme Maker" (November 2021)
+
+this release aims to simplify creating Nimib themes such as nimibook.
+
+It does this through the following changes:
+* instead of creating and injecting multiple variables
+  (`nbDoc`, `nbBlock`, `nbHomeDir`, ...), nimib now only injects a `nb` variable
+  that is a `NbDoc`. Some aliases are provided to minimize breakage.
+* handling of paths (`srcDir` and `homeDir`) is changed and is based on the presence
+  of a new config file `nimib.toml`
+* command line options are now processed and can be used to skip/override the config process.
+  Run any nimib file with option `--nbHelp` to see available options.
+* note in particular new `--nbShow` option which will automatically open the file in your default browser.
+* `nbPostInit` and `nbPreSave` customization mechanism based on includes are now removed 
+* documentation has been updated to reflect the above changes and also to add other Nimib references (NimConf video, nimibook, getting-started, ...)
+most of the changes break the api
+
+relevant external example:
+
+* [norm](https://norm.nim.town) starts to use nimibook for its documentation
+
+Special thanks again to to @Vindaar, @Clonkk and @HugoGranstrom
+
+## 0.1.x (March-June 2021)
+
+a growing ecosystem drives most of the development of the 0.1.x series:
+
+* [intro to binarylang](https://ajusa.github.io/binarylang-fun/intro.html) by @ajusa (March 2021): first public use of nimib by someone other than @pietroppeter 
+* [SciNim Getting Started](https://scinim.github.io/getting-started/) decided to use nimib and for that purpose
+  [nimibook](https://github.com/pietroppeter/nimibook), a book theme (based of mdbook) developments was started
+* [nblog](https://github.com/pietroppeter/nblog), a nimib blog, was started as a way to use nimib to explore nim ecosystem and experiment
+  the various features of nimib
+* [nimiboost](https://github.com/HugoGranstrom/nimiBoost) is a vs code extension to provide
+  markdown highlighting and a preview mechanism.
+
+changes:
+
+*  0.1.1:
+  - add nbPostInit mechanism to customize document (#32)
+  - fix (breaking): code output is escaped by default
+  - fix (breaking): code output is not stripped anymore
+  - fix: nbDoc.write will create directories if not existing (#44)
+* 0.1.2: release to align tag and nimble version
+* 0.1.3: added compile-time switches to override nbHomeDir (#53)
+* 0.1.4: fix for `nbImage` path (#56)
+* 0.1.5: new template `nbCodeInBlock` (#59)
+* 0.1.6: added `nimib / boost` module with `md` and `fmd` helpers to support markdown highlight with nimiboost
+
+Thanks for this release series to @Vindaar, @Clonkk and @HugoGranstrom who decided to adopt
+nimib in scinim/getting-started and motivated and directly contributed to nimib and nimibook development
+to support this use case.
+
+## 0.1 (March 2021)
+
+* initial version with essential templates `nbInit`, `nbText`, `nbCode`, `nbImage`, `nbSave`
+  - capture of output in `nbCode` based on code by @Clonkk
+* html backend based on mustache and markdown by @soasme
+* default theme using water.css
+  - header with home button, minimal title (filename by default), automatic detection of github repo
+  - footer with "made with nimib" and Show Source button
+* static highlighting of nim code (by @yardanico)
+* latex rendering through katex
+* markdown backend
+* essential documentation in `index.nim`
+  - sections: intro, example usage, features, api, roadmap, thanks, Q&A
+  - also generates `README.md` and serves as an example of usage of markdown backend
+* possibility to customize theme (dark mode, custom stylesheet, add other scripts, ...)
+* example documents:
+  - `penguins`: data exploration, adding images
+  - `numerical`: latex usage, theme customization
+  - `cheatsheet`: toc creation, new text block which shows source, custom highlighting
+    - also documents the markdown to html generator
+  - `mostaccio`: example of using dark mode
+    - also documents the templating system mustache
+  - `ptest`: print testing for nimib
+* deployed using github pages. html files committed in repo.
+
+relevant external examples:
+
+* adventofnim (2020) by @pietroppeter
+  - first appeareance of nimib in public (before 0.1 release), see [commit on Dec 1st, 2020](https://github.com/pietroppeter/adventofnim/commit/973f9a2472d41188bb37650c082f115fc5787687#diff-a21a437c51bd7babb945c8291588853296387c7e1950997e05f1eb62d18b54f7)
+
+Initial commit of nimib was on Nov, 25, 2020.
+On the same day the [first milestone](https://github.com/pietroppeter/nimib/commit/b02ec7be4663956167701a81a96246d8e528fff3)
+reached was the working hello world example.
+
+For this release, thanks to:
+
+* [soasme](https://github.com/soasme) for the excellent libraries nim-markdown and nim-mustache, which provide the backbone of nimib rendering and customization
+* [Clonkk](https://github.com/Clonkk) for help in a critical piece of code early on (see [this Stack Overflow answer](https://stackoverflow.com/a/64032172/4178189))
+* [yardanico](https://github.com/yardanico) for being the first contributor and great sponsor of this library, even before an official release

--- a/changelog.md
+++ b/changelog.md
@@ -13,15 +13,24 @@ When contributing a fix, feature or example please add a new line to briefly exp
 
 ## 0.3
 
-## 0.2.x
+## 0.2.x (November 2021)
 
-### 0.2.4
+### 0.2.4 - CodeAsInSource
+
+* Update penguins example which now uses datamancer and shows Simpson's paradaox, by by @Vindaar (#70)
+* code as in source for nbCode (`-d:nimibPreviewCodeAsInSource`) by @HugoGranstrom (#63): with this option the code shown is not derived from Ast but it is read from source code.
 
 ### 0.2.3
 
-### 0.2.2
+* align version in nimble file and tagged version 
+
+### 0.2.2 - nbFile
+
+* add `nbFile` by @Clonkk (#64)
 
 ### 0.2.1
+
+* fix to `path_to_root` (renamed from `home_path`, also `here_path` renamed to `path_to_here`) (#67)
 
 ## 0.2 "Theme Maker" (November 2021)
 

--- a/changelog.md
+++ b/changelog.md
@@ -92,6 +92,9 @@ List of detailed changes:
   - new `nimibCodeFromAst` flag to revert to old default
   - added a warning to `nimibPreviewCodeAsInSource` (now obsolete)
 * various fixes to `CodeAsInSource` (#105, #106, #108)
+* changelog updated and separated from documentation (#103)
+* updated documentation to include most recent changes (#103)
+* fix md output of `index.nim` (#103)
 
 Thanks to @metagn for improving our CI/nimble file! Every contribution counts!
 

--- a/changelog.md
+++ b/changelog.md
@@ -95,6 +95,7 @@ List of detailed changes:
 * changelog updated and separated from documentation (#103)
 * updated documentation to include most recent changes (#103)
 * fix md output of `index.nim` (#103)
+* turned off warning for unused imports in `nimib.nim` (#103)
 
 Thanks to @metagn for improving our CI/nimble file! Every contribution counts!
 

--- a/changelog.md
+++ b/changelog.md
@@ -68,7 +68,7 @@ List of detailed changes:
   - all nimib "native" blocks now use one of the two mechanism above
   - now `nbText` does NOT contain its source
   - new `nbTextWithCode` that does contain code source
-* untyped version of `nbFile` removed, new example document `files.nim`, changed the rendering of `nbFile`
+* new example document `files.nim`, changed the rendering of `nbFile`
   (no more "writing file ..." only the name of file is added) (#81)
 * added `loadNimibCfg` proc that can be used for themes (used by nimibook) (#81)
 * added `nbInitPython` and `nbPython` templates to support running python in nimib documents using `nimpy` (#83)
@@ -113,7 +113,7 @@ Relevant examples of usage:
 
 ### 0.2.4 - CodeAsInSource
 
-* Update penguins example which now uses datamancer and shows Simpson's paradaox, by by @Vindaar (#70)
+* Update penguins example which now uses datamancer and shows Simpson's paradaox, by @Vindaar (#70)
 * code as in source for nbCode (`-d:nimibPreviewCodeAsInSource`) by @HugoGranstrom (#63): with this option the code shown is not derived from Ast but it is read from source code.
 * ptest document is turned off from CI
 

--- a/changelog.md
+++ b/changelog.md
@@ -37,21 +37,39 @@ as maintainer and co-creator of nimib! 🥳
 
 List of detailed changes:
 
-* refactoring of `NbBlock` type and rendering of blocks (#80):
+* refactoring of `NbBlock` type and rendering of blocks (#78, fixes #24):
   * `NbBlock` type is completely refactored. Instead of having a `kind` with a fixed
     number of values, a block behaviour is specified by a `command` string
     which is set to the name of the command template used to create a block
     (e.g. `nbCode`, `nbText`, `nbImage`, ...) - 
+  * `newNbBlock` is now the main template to create a new block
   * Every block now has a `context` field and the rendering backend (either html or markdown)
     has a mechanism to retrieve a `partial` for every command.
   * as an additional mechanism to be able to perform other computations when rendering,
     a sequence of `renderProc`s can be assigned for every command (for a specific backend).
+  * `nimib / renders` module completely refactored to take into account the above changes
   * some other accidental or not so welcome changes that happened during the refactoring:
     - `sugar` is now exported _(accidental)_
     - `nb: NbDoc` is mutated when rendered _(unwelcome, will be changed later)_
     - cannot use both Html and Md backend at the same time _(unwelcome, will be changed later)_
-* fixed cheatsheet document (fixed #52)
-* ptest document is removed (#80)
+* logging has been improved (see changes in `nimib.blocks.newNbBlock`) (#78)
+* new `main` partial introduced (#78)
+* fixed cheatsheet document (#78, fixes #52)
+* tests are added and ptest document is removed (#78)
+* aliases to minimize breaking changes that happened in 0.2 (`nbDoc`, `nbBlock`, `nbHomeDir`) are noew removed (#78)
+* added a new `readCode: bool` parameter to `newNbBlock` (with an overload that sets it as true) (#80)
+* new template `nbRawOutput` that renders raw html (#80)
+* new command `nbClearOutput` that removes output from last block processed (#80)
+* new templates for creating code blocks `newNbCodeBlock` and `newNbSlimBlock`
+  for creating custom blocks and related changes (#81):
+  - `newNbCodeBlock`: captures source code of `body`
+  - `newNbSlimBlock`: block without a `body` (and in particular no capture of source)
+  - all nimib "native" blocks now use one of the two mechanism above
+  - now `nbText` does NOT contain its source
+  - new `nbTextWithCode` that does contain code source
+* untyped version of `nbFile` removed, new example document `files.nim`, changed the rendering of `nbFile`
+  (no more "writing file ..." only the name of file is added) (#81)
+* added `loadNimibCfg` proc that can be used for themes (used by nimibook) (#81)
 
 Thanks to @metagn for improving our CI/nimble file! Every contribution counts!
 

--- a/docsrc/files.nim
+++ b/docsrc/files.nim
@@ -1,14 +1,14 @@
 import nimib
 
 nbInit
-nbText: """## Files in nimib
+nbText: """## `nbFile`
 
-Here is a short example of using files in nimib.
-The api to use is `nbFile`.
+The template `nbFile` can be called with a string
+or with an untyped body.
+
 """
-nbFile("module.nim"): """
-const myNumber* = 42
-"""
+nbFile("module.nim"):
+  const myNumber* = 42
 
 nbFile("main.nim"): """
 import module

--- a/docsrc/index.nim
+++ b/docsrc/index.nim
@@ -107,9 +107,11 @@ you are welcome to add here what you have built with nimib!
 The following are the main elements of a default nimib document:
 
 * `nbInit`: initializes a nimib document, required for all other commands to work.
-* `nbCode`: code blocks with automatic stdout capture
+  In particular it creates and injects into scope a `nb` object used by all other blocks
+  (see below section API for internal details).
+* `nbCode`: code blocks with automatic stdout capture and capture of code source
 * `nbText`: text blocks with automatic conversion from markdown to html (thanks to [nim-markdown](https://github.com/soasme/nim-markdown))
-* `nbImage`: image command to show images
+* `nbImage`: image command to show images (see `penguins.nim` example linked above)
 * `nbSave`: save the document (by default to html)
 * styling with [water.css](https://watercss.kognise.dev/), light mode is default, dark mode available (`nb.darkMode` after `nbInit`).
 * static highlighting of nim code. Highlight styling classes are the same of [highlightjs](https://highlightjs.org/)
@@ -122,6 +124,10 @@ The following are the main elements of a default nimib document:
 Customization over the default is mostly achieved through nim-mustache or changing
 `NbDoc` and `NbBlock` elements (see below api).
 Currently most of the documentation on customization is given by the examples.
+
+### other templates
+
+* `nbFile`: content (string or untyped) is saved to file (see example document [files]({docs}/files.html))
 
 ### latex
 
@@ -174,6 +180,19 @@ nbText: hlMdF"""
 The value of options are available in `nb.options` field which also
 tracks further options in `nb.options.other: seq[tuple[kind: CmdLineKind; name, value: string]]`.
 
+### Code capture
+
+The code capture of a block like `nbCode` (or other custom blocks)
+can happen in two different ways:
+
+* `CodeAsInSource` (default since version 0.3): code for a single block
+  is parsed from file source (available in `nb.source`).
+* `CodeFromAst` (default in versions 0.1 and 0.2): code for a single block
+  is rendered from AST of body. This means that only documentation comments
+  are shown (since normal comments are not part of the AST) and that the source show
+  might be different from original source.
+  Since version 0.3 this is available through compile time switch `nimibCodeFromAst`.
+
 ## :honeybee: API <!-- Api means bees in Italian -->
 
 * `nbInit` template creates and injects a `nb` variable of type `NbDoc`.
@@ -182,8 +201,6 @@ tracks further options in `nb.options.other: seq[tuple[kind: CmdLineKind; name, 
 * the last processed block is available as `nb.blk`
 * `nb.blk.output` contains the (non rendered) output of block
 * `nb.blk.code` contains the source code of the block
-* currently the source code is a stringification of AST and as such it might be
-  formatted differently than the actual source
 * Work is ongoing to have the code source exactly as in source file (see PR ([#63](https://github.com/pietroppeter/nimib/pull/63)))
 * `NbBlock` is a ref object, so changing `nb.blk`, changes the last block in `nb.blocks`.
 * rendering happens during the call of `nbSave` and and calls a `nb.render` proc

--- a/docsrc/index.nim
+++ b/docsrc/index.nim
@@ -111,7 +111,6 @@ The following are the main elements of a default nimib document:
   (see below section API for internal details).
 * `nbCode`: code blocks with automatic stdout capture and capture of code source
 * `nbText`: text blocks with automatic conversion from markdown to html (thanks to [nim-markdown](https://github.com/soasme/nim-markdown))
-* `nbImage`: image command to show images (see `penguins.nim` example linked above)
 * `nbSave`: save the document (by default to html)
 * styling with [water.css](https://watercss.kognise.dev/), light mode is default, dark mode available (`nb.darkMode` after `nbInit`).
 * static highlighting of nim code. Highlight styling classes are the same of [highlightjs](https://highlightjs.org/)
@@ -127,7 +126,35 @@ Currently most of the documentation on customization is given by the examples.
 
 ### other templates
 
+* `nbImage`: image command to show images (see `penguins.nim` example linked above)
 * `nbFile`: content (string or untyped) is saved to file (see example document [files]({docs}/files.html))
+* `nbRawOutput`: called with string content, it will add the raw content to document (html backend)
+* `nbTextWithCode`: a variant of `nbText` that also reads nim source. See example of usage
+  at the end of the source in `numerical.nim` linked above.
+* `nbPython`:  can be used after calling `nbInitPython()` and it runs and capture output of python code;
+  requires [nimpy](https://github.com/yglukhov/nimpy).
+
+### creating custom blocks
+
+* `newNbCodeBlock(cmd: string, body, blockImpl: untyped)`: template that can be used to create custom
+  code block that will need both a `body` and an implementation which might make use of `body`.
+  Also, the source code in `body` is read.
+  Example blocks created with `newNbCodeBlock` are `nbCode` and `nbTextWithCode`.
+* `newNbSlimBlock(cmd: string, blockImpl: untyped)`: template that can be used to create
+  a custom block that does not need a separate `body`.
+  Example blocks created with `newNbSlimBlock` are `nbText`, `nbImage` and `nbFile`.
+
+See `src/nimib.nim` for examples on nimib blocks that are built using these two templates.
+
+### interactivity using nim js backend
+
+Nimib can incorporate javascript code generated from nim code using template `nbCodeToJs`.
+It also provides a template `nbKaraxCode` to add code based on [karax](https://github.com/karaxnim/karax).
+
+See [interactivity]({docs}/interactivity.html) for an explanation of the api
+and [counter]({docs}/counters.html) for examples of how to create widgets using it.
+In [caesar]({docs}/caesar.html) we have an example of a karax app
+that implements [Caesar cipher](https://en.wikipedia.org/wiki/Caesar_cipher).
 
 ### latex
 
@@ -168,7 +195,7 @@ that allow to override the above value, skip the config file or other options.
 
 All the options available can be seen by running any nimib file with option `nbHelp`
 (execution will stop after `nbInit`).
-"""
+""".emojize
 
 nbCode:
   import osproc

--- a/docsrc/index.nim
+++ b/docsrc/index.nim
@@ -222,6 +222,7 @@ most of the changes break the api
 * latex rendering through katex
 * markdown backend
 * essential documentation in `index.nim`
+  - sections: intro, example usage, features, api, roadmap, thanks, Q&A
   - also generates `README.md` and serves as an example of usage of markdown backend
 * possibility to customize theme (dark mode, custom stylesheet, add other scripts, ...)
 * example documents:

--- a/docsrc/index.nim
+++ b/docsrc/index.nim
@@ -11,7 +11,7 @@ nb.title = "Nimib Docs"
 
 let
   repo = "https://github.com/pietroppeter/nimib"
-  docs = if defined(useMdBackend): "https://pietroppeter.github.io/nimib" else: "."
+  docs = if defined(mdOutput): "https://pietroppeter.github.io/nimib" else: "."
   hello = read(nb.srcDir / "hello.nim".RelativeFile)
 
 nbText: hlMdF"""

--- a/docsrc/index.nim
+++ b/docsrc/index.nim
@@ -235,7 +235,16 @@ most of the changes break the api
   - `ptest`: print testing for nimib
 * deployed using github pages. html files committed in repo.
 
-for this release, thanks to:
+relevant external examples:
+
+* adventofnim (2020) by @pietroppeter
+  - first appeareance of nimib in public (before 0.1 release), see [commit on Dec 1st, 2020](https://github.com/pietroppeter/adventofnim/commit/973f9a2472d41188bb37650c082f115fc5787687#diff-a21a437c51bd7babb945c8291588853296387c7e1950997e05f1eb62d18b54f7)
+
+Initial commit of nimib was on Nov, 25, 2020.
+On the same day the [first milestone](https://github.com/pietroppeter/nimib/commit/b02ec7be4663956167701a81a96246d8e528fff3)
+reached was the working hello world example.
+
+For this release, thanks to:
 
 * [soasme](https://github.com/soasme) for the excellent libraries nim-markdown and nim-mustache, which provide the backbone of nimib rendering and customization
 * [Clonkk](https://github.com/Clonkk) for help in a critical piece of code early on (see [this Stack Overflow answer](https://stackoverflow.com/a/64032172/4178189))

--- a/docsrc/index.nim
+++ b/docsrc/index.nim
@@ -1,7 +1,10 @@
-import nimib, strformat, nimoji, nimib / renders
+import nimib, strformat, nimoji
+from nimib / renders import useMdBackend
+from nimib / themes import noTheme
 
 when defined(mdOutput):
-  nbInit(backend=useMdBackend)
+  echo "using Markdown backend"
+  nbInit(backend=useMdBackend, theme=noTheme)
 else:
   nbInit
 nb.title = "Nimib Docs"
@@ -206,7 +209,7 @@ All the options available can be seen by running any nimib file with option `nbH
 nbCode:
   import osproc
   withDir nb.srcDir:
-    echo execProcess("nim r --verbosity:0 --hints:off --warning:UnusedImport:off hello --nbHelp")
+    echo execProcess("nim r --verbosity:0 --hints:off hello --nbHelp")
 
 nbText: hlMdF"""
 

--- a/docsrc/index.nim
+++ b/docsrc/index.nim
@@ -210,6 +210,36 @@ most of the changes break the api
   Run any nimib file with option `--nbHelp` to see available options.
 * `nbPostInit` and `nbPreSave` customization mechanism based on includes are now removed 
 
+### 0.1 - March 2021
+
+* initial version with essential templates `nbInit`, `nbText`, `nbCode`, `nbImage`, `nbSave`
+  - capture of output in `nbCode` based on code by @Clonkk
+* html backend based on mustache and markdown by @soasme
+* default theme using water.css
+  - header with home button, minimal title (filename by default), automatic detection of github repo
+  - footer with "made with nimib" and Show Source button
+* static highlighting of nim code (by @yardanico)
+* latex rendering through katex
+* markdown backend
+* essential documentation in `index.nim`
+  - also generates `README.md` and serves as an example of usage of markdown backend
+* possibility to customize theme (dark mode, custom stylesheet, add other scripts, ...)
+* example documents:
+  - `penguins`: data exploration, adding images
+  - `numerical`: latex usage, theme customization
+  - `cheatsheet`: toc creation, new text block which shows source, custom highlighting
+    - also documents the markdown to html generator
+  - `mostaccio`: example of using dark mode
+    - also documents the templating system mustache
+  - `ptest`: print testing for nimib
+* deployed using github pages. html files committed in repo.
+
+for this release, thanks to:
+
+* [soasme](https://github.com/soasme) for the excellent libraries nim-markdown and nim-mustache, which provide the backbone of nimib rendering and customization
+* [Clonkk](https://github.com/Clonkk) for help in a critical piece of code early on (see [this Stack Overflow answer](https://stackoverflow.com/a/64032172/4178189))
+* [yardanico](https://github.com/yardanico) for being the first contributor and great sponsor of this library, even before an official release
+
 ## :sunrise: Roadmap
 
 - refactor rendering of blocks and simplify api extensions ([#24](https://github.com/pietroppeter/nimib/issues/24))
@@ -226,9 +256,6 @@ most of the changes break the api
 
 to:
 
-* [soasme](https://github.com/soasme) for the excellent libraries nim-markdown and nim-mustache, which provide the backbone of nimib rendering and customization
-* [Clonkk](https://github.com/Clonkk) for help in a critical piece of code early on (see [this Stack Overflow answer](https://stackoverflow.com/a/64032172/4178189))
-* [yardanico](https://github.com/yardanico) for being the first contributor and great sponsor of this library, even before an official release
 * [vindaar](https://github.com/Vindaar),
   [hugogranstrom](https://github.com/HugoGranstrom)
   for their contributions towards version 0.2.

--- a/docsrc/index.nim
+++ b/docsrc/index.nim
@@ -197,107 +197,23 @@ Here are two examples that show how to hijack the api:
 
 ## Changelog and :pray: Thanks
 
-### 0.2 "Theme Maker" (November 2021)
-
-this release aims to simplify creating Nimib themes such as nimibook.
-
-It does this through the following changes:
-* instead of creating and injecting multiple variables
-  (`nbDoc`, `nbBlock`, `nbHomeDir`, ...), nimib now only injects a `nb` variable
-  that is a `NbDoc`. Some aliases are provided to minimize breakage.
-* handling of paths (`srcDir` and `homeDir`) is changed and is based on the presence
-  of a new config file `nimib.toml`
-* command line options are now processed and can be used to skip/override the config process.
-  Run any nimib file with option `--nbHelp` to see available options.
-* note in particular new `--nbShow` option which will automatically open the file in your default browser.
-* `nbPostInit` and `nbPreSave` customization mechanism based on includes are now removed 
-* documentation has been updated to reflect the above changes and also to add other Nimib references (NimConf video, nimibook, getting-started, ...)
-most of the changes break the api
-
-relevant external example:
-
-* [norm](https://norm.nim.town) starts to use nimibook for its documentation
-
-### 0.1.x (March-June 2021)
-
-a growing ecosystem drives most of the development of the 0.1.x series:
-
-* [intro to binarylang](https://ajusa.github.io/binarylang-fun/intro.html) by @ajusa (March 2021): first public use of nimib by someone other than @pietroppeter 
-* [SciNim Getting Started](https://scinim.github.io/getting-started/) decided to use nimib and for that purpose
-  [nimibook](https://github.com/pietroppeter/nimibook), a book theme (based of mdbook) developments was started
-* [nblog](https://github.com/pietroppeter/nblog), a nimib blog, was started as a way to use nimib to explore nim ecosystem and experiment
-  the various features of nimib
-* [nimiboost](https://github.com/HugoGranstrom/nimiBoost) is a vs code extension to provide
-  markdown highlighting and a preview mechanism.
-
-changes:
-
-*  0.1.1:
-  - add nbPostInit mechanism to customize document (#32)
-  - fix (breaking): code output is escaped by default
-  - fix (breaking): code output is not stripped anymore
-  - fix: nbDoc.write will create directories if not existing (#44)
-* 0.1.2: release to align tag and nimble version
-* 0.1.3: added compile-time switches to override nbHomeDir (#53)
-* 0.1.4: fix for `nbImage` path (#56)
-* 0.1.5: new template `nbCodeInBlock` (#59)
-* 0.1.6: added `nimib / boost` module with `md` and `fmd` helpers to support markdown highlight with nimiboost
-
-Thanks for this release series to @Vindaar, @Clonkk and @HugoGranstrom who decided to adopt
-nimib in scinim/getting-started and motivated and directly contributed to nimib and nimibook development
-to support this use case.
-
-### 0.1 (March 2021)
-
-* initial version with essential templates `nbInit`, `nbText`, `nbCode`, `nbImage`, `nbSave`
-  - capture of output in `nbCode` based on code by @Clonkk
-* html backend based on mustache and markdown by @soasme
-* default theme using water.css
-  - header with home button, minimal title (filename by default), automatic detection of github repo
-  - footer with "made with nimib" and Show Source button
-* static highlighting of nim code (by @yardanico)
-* latex rendering through katex
-* markdown backend
-* essential documentation in `index.nim`
-  - sections: intro, example usage, features, api, roadmap, thanks, Q&A
-  - also generates `README.md` and serves as an example of usage of markdown backend
-* possibility to customize theme (dark mode, custom stylesheet, add other scripts, ...)
-* example documents:
-  - `penguins`: data exploration, adding images
-  - `numerical`: latex usage, theme customization
-  - `cheatsheet`: toc creation, new text block which shows source, custom highlighting
-    - also documents the markdown to html generator
-  - `mostaccio`: example of using dark mode
-    - also documents the templating system mustache
-  - `ptest`: print testing for nimib
-* deployed using github pages. html files committed in repo.
-
-relevant external examples:
-
-* adventofnim (2020) by @pietroppeter
-  - first appeareance of nimib in public (before 0.1 release), see [commit on Dec 1st, 2020](https://github.com/pietroppeter/adventofnim/commit/973f9a2472d41188bb37650c082f115fc5787687#diff-a21a437c51bd7babb945c8291588853296387c7e1950997e05f1eb62d18b54f7)
-
-Initial commit of nimib was on Nov, 25, 2020.
-On the same day the [first milestone](https://github.com/pietroppeter/nimib/commit/b02ec7be4663956167701a81a96246d8e528fff3)
-reached was the working hello world example.
-
-For this release, thanks to:
-
-* [soasme](https://github.com/soasme) for the excellent libraries nim-markdown and nim-mustache, which provide the backbone of nimib rendering and customization
-* [Clonkk](https://github.com/Clonkk) for help in a critical piece of code early on (see [this Stack Overflow answer](https://stackoverflow.com/a/64032172/4178189))
-* [yardanico](https://github.com/yardanico) for being the first contributor and great sponsor of this library, even before an official release
+In the [changelog](changelog.md) you find all recent changes, some early history of nimib, pointers to relevant
+examples of usage of nimib and heartfelt thanks to some of the fine folks that
+made this development possible.
 
 ## :sunrise: Roadmap
 
-- refactor rendering of blocks and simplify api extensions ([#24](https://github.com/pietroppeter/nimib/issues/24))
 - add more themes such as [nimibook](https://github.com/pietroppeter/nimibook).
   In particular themes for blogging and for creating general websites.
-- client-side dynamic site: interactivity of documents, e.g. a dahsboard (possibly taking advantage of nim js backend)
-- can I use nimib to build a library directly from documentation?
+- can I use nimib to build a library directly from documentation (like in [nbdev](https://github.com/fastai/nbdev))?
 - nimib executable for scaffolding and to support different publishing workflows
 - server-side dynamic sites (streamlit style? take advantage of caching instead of hot code reloading)
 - possibility of editing document in the browser (similar to jupyter UI, not necessarily taking advantage of hot code reloading)
 - ...
+
+completed in 0.3:
+- [x] refactor rendering of blocks and simplify api extensions ([#24](https://github.com/pietroppeter/nimib/issues/24))
+- [x] client-side dynamic site: interactivity of documents, e.g. a dahsboard (possibly taking advantage of nim js backend)
 
 ## :question: :exclamation: Q & A
 

--- a/docsrc/index.nim
+++ b/docsrc/index.nim
@@ -1,6 +1,9 @@
 import nimib, strformat, nimoji, nimib / renders
 
-nbInit
+when defined(mdOutput):
+  nbInit(backend=useMdBackend)
+else:
+  nbInit
 nb.title = "Nimib Docs"
 
 let
@@ -200,7 +203,7 @@ All the options available can be seen by running any nimib file with option `nbH
 nbCode:
   import osproc
   withDir nb.srcDir:
-    echo execProcess("nim r --verbosity:0 --hints:off hello --nbHelp")
+    echo execProcess("nim r --verbosity:0 --hints:off --warning:UnusedImport:off hello --nbHelp")
 
 nbText: hlMdF"""
 
@@ -310,9 +313,8 @@ because [someone made it into an art form](https://github.com/oakes/vim_cubed#q-
 and they tell me [imitation is the sincerest form of flattery](https://www.goodreads.com/quotes/558084-imitation-is-the-sincerest-form-of-flattery-that-mediocrity-can)
 """.emojize
 
-when not defined(useMdBackend):
+when defined(mdOutput):
+  nb.filename = "../README.md"
   nbSave
 else:
-  nb.useMdBackend
-  nb.filename = "../README.md"
   nbSave

--- a/docsrc/index.nim
+++ b/docsrc/index.nim
@@ -136,6 +136,9 @@ Currently most of the documentation on customization is given by the examples.
   at the end of the source in `numerical.nim` linked above.
 * `nbPython`:  can be used after calling `nbInitPython()` and it runs and capture output of python code;
   requires [nimpy](https://github.com/yglukhov/nimpy).
+* `nbClearOutput`: clears the output of preceding code block,
+  useful in case a previous command has produced output that you do not want to show for some reason.
+
 
 ### creating custom blocks
 

--- a/docsrc/index.nim
+++ b/docsrc/index.nim
@@ -11,7 +11,7 @@ let
   highlight = "highlight.nim.js"
   defaultHighlightCss = "atom-one-light.css"
 
-nbText: fmd"""
+nbText: hlMdF"""
 # nimib :whale: - nim :crown: driven :sailboat: publishing :writingHand:
 
 Nimib provides an API to convert your Nim code and its outputs to html documents.
@@ -73,7 +73,7 @@ else:
 ```"""
 
 
-nbText: fmd"""
+nbText: hlMdF"""
 ### Other examples of usage
 
 in this repo:
@@ -159,8 +159,20 @@ Inside a config file you can define two special directory:
 
 `nbInit` also parses command line options that start with `nb` or `nimib`
 that allow to override the above value, skip the config file or other options.
-To see all the options execute any nimib file with option `nbHelp`.
 
+All the options available can be seen by running any nimib file with option `nbHelp`
+(execution will stop after `nbInit`).
+"""
+
+nbCode:
+  import osproc
+  withDir nb.srcDir:
+    echo execProcess("nim r --verbosity:0 --hints:off hello --nbHelp")
+
+nbText: hlMdF"""
+
+The value of options are available in `nb.options` field which also
+tracks further options in `nb.options.other: seq[tuple[kind: CmdLineKind; name, value: string]]`.
 
 ## :honeybee: API <!-- Api means bees in Italian -->
 

--- a/docsrc/index.nim
+++ b/docsrc/index.nim
@@ -197,10 +197,11 @@ Here are two examples that show how to hijack the api:
 
 ## Changelog
 
-### 0.2 (November 2021)
+### 0.2 "Theme Maker" (November 2021)
 
-most of the changes break the api
+this release aims to simplify creating Nimib themes such as nimibook.
 
+It does this through the following changes:
 * instead of creating and injecting multiple variables
   (`nbDoc`, `nbBlock`, `nbHomeDir`, ...), nimib now only injects a `nb` variable
   that is a `NbDoc`. Some aliases are provided to minimize breakage.
@@ -208,7 +209,14 @@ most of the changes break the api
   of a new config file `nimib.toml`
 * command line options are now processed and can be used to skip/override the config process.
   Run any nimib file with option `--nbHelp` to see available options.
+* note in particular new `--nbShow` option which will automatically open the file in your default browser.
 * `nbPostInit` and `nbPreSave` customization mechanism based on includes are now removed 
+* documentation has been updated to reflect the above changes and also to add other Nimib references (NimConf video, nimibook, getting-started, ...)
+most of the changes break the api
+
+relevant external example:
+
+* [norm](https://norm.nim.town) starts to use nimibook for its documentation
 
 ### 0.1.x (March-June 2021)
 

--- a/docsrc/index.nim
+++ b/docsrc/index.nim
@@ -195,7 +195,7 @@ Here are two examples that show how to hijack the api:
 * [nolan]({docs}/nolan.html): how to mess up the timeline of blocks :hourglass_flowing_sand:
 * [pythno]({docs}/pythno.html): a reminder that nim is not python :stuck_out_tongue_winking_eye:
 
-## Changelog
+## Changelog and :pray: Thanks
 
 ### 0.2 "Theme Maker" (November 2021)
 
@@ -242,6 +242,10 @@ changes:
 * 0.1.4: fix for `nbImage` path (#56)
 * 0.1.5: new template `nbCodeInBlock` (#59)
 * 0.1.6: added `nimib / boost` module with `md` and `fmd` helpers to support markdown highlight with nimiboost
+
+Thanks for this release series to @Vindaar, @Clonkk and @HugoGranstrom who decided to adopt
+nimib in scinim/getting-started and motivated and directly contributed to nimib and nimibook development
+to support this use case.
 
 ### 0.1 (March 2021)
 
@@ -294,14 +298,6 @@ For this release, thanks to:
 - server-side dynamic sites (streamlit style? take advantage of caching instead of hot code reloading)
 - possibility of editing document in the browser (similar to jupyter UI, not necessarily taking advantage of hot code reloading)
 - ...
-
-## :pray: Thanks
-
-to:
-
-* [vindaar](https://github.com/Vindaar),
-  [hugogranstrom](https://github.com/HugoGranstrom)
-  for their contributions towards version 0.2.
 
 ## :question: :exclamation: Q & A
 

--- a/docsrc/index.nim
+++ b/docsrc/index.nim
@@ -148,7 +148,7 @@ Currently most of the documentation on customization is given by the examples.
   Example blocks created with `newNbCodeBlock` are `nbCode` and `nbTextWithCode`.
 * `newNbSlimBlock(cmd: string, blockImpl: untyped)`: template that can be used to create
   a custom block that does not need a separate `body`.
-  Example blocks created with `newNbSlimBlock` are `nbText`, `nbImage` and `nbFile`.
+  Example blocks created with `newNbSlimBlock` are `nbText`, `nbImage`.
 
 See `src/nimib.nim` for examples on nimib blocks that are built using these two templates.
 
@@ -272,7 +272,7 @@ Here are two examples that show how to hijack the api:
 
 ## Changelog and :pray: Thanks
 
-In the [changelog](changelog.md) you find all recent changes, some early history of nimib, pointers to relevant
+In the [changelog]({repo}/blob/main/changelog.md) you find all recent changes, some early history of nimib, pointers to relevant
 examples of usage of nimib and heartfelt thanks to some of the fine folks that
 made this development possible.
 

--- a/docsrc/index.nim
+++ b/docsrc/index.nim
@@ -197,7 +197,7 @@ Here are two examples that show how to hijack the api:
 
 ## Changelog
 
-### 0.2
+### 0.2 (November 2021)
 
 most of the changes break the api
 
@@ -210,7 +210,32 @@ most of the changes break the api
   Run any nimib file with option `--nbHelp` to see available options.
 * `nbPostInit` and `nbPreSave` customization mechanism based on includes are now removed 
 
-### 0.1 - March 2021
+### 0.1.x (March-June 2021)
+
+a growing ecosystem drives most of the development of the 0.1.x series:
+
+* [intro to binarylang](https://ajusa.github.io/binarylang-fun/intro.html) by @ajusa (March 2021): first public use of nimib by someone other than @pietroppeter 
+* [SciNim Getting Started](https://scinim.github.io/getting-started/) decided to use nimib and for that purpose
+  [nimibook](https://github.com/pietroppeter/nimibook), a book theme (based of mdbook) developments was started
+* [nblog](https://github.com/pietroppeter/nblog), a nimib blog, was started as a way to use nimib to explore nim ecosystem and experiment
+  the various features of nimib
+* [nimiboost](https://github.com/HugoGranstrom/nimiBoost) is a vs code extension to provide
+  markdown highlighting and a preview mechanism.
+
+changes:
+
+*  0.1.1:
+  - add nbPostInit mechanism to customize document (#32)
+  - fix (breaking): code output is escaped by default
+  - fix (breaking): code output is not stripped anymore
+  - fix: nbDoc.write will create directories if not existing (#44)
+* 0.1.2: release to align tag and nimble version
+* 0.1.3: added compile-time switches to override nbHomeDir (#53)
+* 0.1.4: fix for `nbImage` path (#56)
+* 0.1.5: new template `nbCodeInBlock` (#59)
+* 0.1.6: added `nimib / boost` module with `md` and `fmd` helpers to support markdown highlight with nimiboost
+
+### 0.1 (March 2021)
 
 * initial version with essential templates `nbInit`, `nbText`, `nbCode`, `nbImage`, `nbSave`
   - capture of output in `nbCode` based on code by @Clonkk

--- a/nimib.nimble
+++ b/nimib.nimble
@@ -15,7 +15,7 @@ requires "mustache >= 0.2.1"
 requires "toml_serialization >= 0.2.0"
 
 task docsdeps, "install dependendencies required for doc building":
-  exec "nimble -y install ggplotnim@0.4.9 numericalnim@0.6.1 nimoji nimpy karax@#head"
+  exec "nimble -y install ggplotnim@0.4.9 numericalnim@0.6.1 nimoji nimpy karax@1.2.2"
 
 task test, "General tests":
   exec "nim r tests/tsources.nim"

--- a/nimib.nimble
+++ b/nimib.nimble
@@ -27,7 +27,7 @@ task test, "General tests":
   exec "nim r -d:nimibCodeFromAst tests/trenders.nim"
 
 task readme, "update readme":
-  exec "nim -d:useMdBackend r docsrc/index.nim"  
+  exec "nim -d:mdOutput r docsrc/index.nim"  
 
 task docs, "Build documentation":
   exec "nim r docsrc/hello.nim"

--- a/src/nimib.nim
+++ b/src/nimib.nim
@@ -58,6 +58,8 @@ template nbInit*(theme = themes.useDefault, backend = renders.useHtmlBackend, th
   # apply theme
   theme nb
 
+template nbInitMd* = nbInit(backend=renders.useMdBackend, theme=themes.noTheme)
+
 # block generation templates
 template newNbCodeBlock*(cmd: string, body, blockImpl: untyped) =
   newNbBlock(cmd, true, nb, nb.blk, body, blockImpl)

--- a/src/nimib.nim
+++ b/src/nimib.nim
@@ -1,4 +1,4 @@
-import std/[os, strutils, sugar, strformat, macros, macrocache, sequtils, jsonutils, random]
+import std/[os, strutils, sugar, strformat, macros, macrocache, sequtils, jsonutils]
 export jsonutils
 import nimib / [types, blocks, docs, boost, config, options, capture, jsutils]
 export types, blocks, docs, boost, sugar, jsutils
@@ -186,3 +186,6 @@ template nbHomeDir*: AbsoluteDir = nb.homeDir
 template nbShow* =
   nbSave
   open nb
+
+# should we use this? currently a run of index will show unused random, sequtils, strutils
+# {. warning[UnusedImport]:off .}

--- a/src/nimib.nim
+++ b/src/nimib.nim
@@ -187,5 +187,5 @@ template nbShow* =
   nbSave
   open nb
 
-# should we use this? currently a run of index will show unused random, sequtils, strutils
-# {. warning[UnusedImport]:off .}
+# the following does not affect user imports but only imports not exported in this module
+{. warning[UnusedImport]:off .}

--- a/src/nimib/renders.nim
+++ b/src/nimib/renders.nim
@@ -77,14 +77,18 @@ proc useMdBackend*(doc: var NbDoc) =
 {{>nbCodeSource}}
 {{>nbCodeOutput}}"""
   doc.partials["nbCodeSource"] = """
+
 ```nim
 {{code}}
 ```
+
 """
   doc.partials["nbCodeOutput"] = """{{#output}}
+
 ```
 {{output}}
 ```
+
 {{/output}}
 """
   doc.partials["nbImage"] = """
@@ -107,16 +111,23 @@ proc useMdBackend*(doc: var NbDoc) =
   doc.renderPlans = initTable[string, seq[string]]()
   doc.renderProcs = initTable[string, NbRenderProc]()
 
+template debugRender(message: string) =
+  when defined(nimibDebugRender):
+    echo "[nimib.debugRender] ", message
+
 proc render*(nb: var NbDoc, blk: var NbBlock): string =
+  debugRender "rendering block " & blk.command
   if blk.command not_in nb.partials:
     echo "[nimib.warning] no partial found for block ", blk.command
     return
   else:
     if blk.command in nb.renderPlans:
+      debugRender "renderPlan " & $nb.renderPlans[blk.command]
       for step in nb.renderPlans[blk.command]:
         if step in nb.renderProcs:
           nb.renderProcs[step](nb, blk)
     blk.context.searchTable(nb.partials)
+    debugRender "partial " & nb.partials[blk.command]
     result = nb.partials[blk.command].render(blk.context)
 
 proc render*(nb: var NbDoc): string =

--- a/src/nimib/renders.nim
+++ b/src/nimib/renders.nim
@@ -1,4 +1,4 @@
-import std / [strutils, tables, sugar, os, strformat, random, sequtils]
+import std / [strutils, tables, sugar, os, strformat, sequtils]
 import types, markdown, mustache
 export escapeTag # where is this used? why do I export? a better solution is to use xmlEncode
 import highlight

--- a/src/nimib/themes.nim
+++ b/src/nimib/themes.nim
@@ -156,3 +156,6 @@ proc useLatex*(doc: var NbDoc) =
 proc `title=`*(doc: var NbDoc, text: string) =
   # to deprecate?
   doc.context["title"] = text
+
+proc noTheme*(doc: var NbDoc) =
+  discard


### PR DESCRIPTION
fixes #85 (last step before tagging and releasing)

- improve changelog
- make sure all important changes (recent and older) are documented

details:

- [x] improving changelog and integrating thanks in changelog
  - [x] 0.1
  - [x] 0.1.x
  - [x] 0.2
  - [x] 0.2.x
  - [x] 0.3
  - [x] move changelog to separate file
- [x] improve documentation for some of the recent changes (from 0.2.0 until now)
  - [x] stuff in 0.2.0 that went un(der)documented
    - [x] add list of command line options generated with `nbInit`
  - [x] changes in 0.2.x
    - [x] 0.2.2: nbFile
  - [x] other 0.3 improvements by Hugo #80
    - [x] nbRawOutput
    - [x] nbClearOutput
  - [x] release 0.3 stuff #81
    - [x] newNbCodeBlock
    - [x] newNbSlimBlock
    - [x] new nbTextWithCode that does read code
    - [x] example files.nim for File
  - [x] nbPython # 83
    - [x] nbInitPython and nbPython
  - [x] nim to javascript #88 - added a section
    - [x] nbCodeToJs (or by pieces nbInitToJs, addCodeToJs, addToDocAsJs)
    - [x] nbKaraxCode
  - [x] CodeAsInSource now the default:
    - [x] remove bullet point in API section
    - [x] add section "Code Capture"
  - [x] make sure to rerun nimble readme to have readme updated (currently missing the interactivity docs)
- [x] other changes
  - [x] turned off warning for unused imports in `nimib.nim` (#103)
  - [x] fix md output of index.nim (bug in markdown backend?)


- some other improvements that could be done later: https://github.com/pietroppeter/nimib/issues/110