### PR TITLE
fix codeblocks starting with a block

### DIFF
--- a/src/nimib/sources.nim
+++ b/src/nimib/sources.nim
@@ -25,7 +25,8 @@ proc startPos*(node: NimNode): Pos =
   case node.kind:
     of nnkNone .. nnkNilLit, nnkDiscardStmt, nnkCommentStmt:
       result = toPos(node.lineInfoObj())
-
+    of nnkBlockStmt:
+      result = node[1].startPos()
     else:
       result = node[0].startPos()
 

--- a/tests/tsources.nim
+++ b/tests/tsources.nim
@@ -74,6 +74,12 @@ end"""
   expected = "let garbage = 1\nlet bigString = \"\"\"start\n  middle\nend\"\"\""
   check
 
+  nbCode:
+    block:
+      echo y
+  expected = "block:\n  echo y"
+  check
+
   when not defined(nimibCodeFromAst):
     nbCode:
       echo y
@@ -93,3 +99,5 @@ end"""
     # Don't include this!
     expected = "echo y"
     check
+
+  


### PR DESCRIPTION
Hehe should have run it on getting-started **before** merging it 🙃 Code blocks starting with `block:` resulted in invalid code lines. I've fixed this by getting the lineinfo from the correct child and added a test.

Trying to get the getting-started to run locally now. If I find any more errors I'll add them to this PR as well.