### PR TITLE
fix newline at beginning of code block

### DIFF
--- a/src/nimib/sources.nim
+++ b/src/nimib/sources.nim
@@ -65,6 +65,9 @@ proc findStartLine*(source: seq[string], command: string, startPos: int): int =
   result = startPos
   while not source[result-1].isCommandLine(command):
     dec result
+  # Remove empty lines at the beginning of the block
+  while source[result].isEmptyOrWhitespace:
+    inc result
 
 proc findEndLine*(source: seq[string], command: string, startLine, endPos: int): int =
   result = endPos

--- a/tests/tsources.nim
+++ b/tests/tsources.nim
@@ -100,4 +100,11 @@ end"""
     expected = "echo y"
     check
 
+    nbCode:
+
+      echo y
+    # The newline at the beginning of the block!
+    expected = "echo y"
+    check
+
   


### PR DESCRIPTION
Sigh... This should be the last one from getting-started at least now. 

Starting a code block with a newline tricked it into thinking the indentation of the block was zero and thus all code below it in the file belonged to the the block. 