### PR TITLE
nbJs Maintainance

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,9 @@ When contributing a fix, feature or example please add a new line to briefly exp
 ## 0.3.x
 
 * fix "Did not parse stylesheet at 'https://unpkg.com/normalize.css/' in strict mode" (#120)
+* Split untyped and string versions of `nbCodeToJs` into `nbJsFromCode` and `nbJsFromString`. Same for `nbCodeToJsInit` → `nbJsFromCodeInit`, `nbJsFromStringInit` (#125)
+* Add `postRender` template to `nbKaraxCode` (#125)
+* `nbJsFromCode` now respects `exportc` pragma (#125)
 * _add next change here_
 
 ## 0.3 "Block Maker" (July 2022)

--- a/docsrc/counters.nim
+++ b/docsrc/counters.nim
@@ -6,7 +6,7 @@ nbInit
 nbText: hlMd"""
 # Counters - Creating reusable widgets
 
-This document will show you how to create reusable widgets using `nbCodeToJs`. Specifically we will make a counter:
+This document will show you how to create reusable widgets using `nbJsFromCode`. Specifically we will make a counter:
 A button which increases a counter each time you click it. We will do this in two different ways, using `std/dom` and `karax`.
 ## std/dom
 
@@ -23,7 +23,7 @@ nbCode:
 <button id="$2">Click me</button>
 """ % [labelId, buttonId]
     ## 3:
-    nbCodeToJs(labelId, buttonId):
+    nbJsFromCode(labelId, buttonId):
       import std/dom
       ## 4:
       var label = getElementById(labelId.cstring)
@@ -41,7 +41,7 @@ Let's explain each part of the code:
 1. We define a template called `counterButton` which will create a new counter button. So if you call it somewhere it will
 place the widget there, that's the reusable part done. But it also takes an input `id: string`. This is to solve the problem of each widget needing unique ids. It can also be done with `nb.newId` as will be used in the Karax example.
 2. Here we emit the `<label>` and `<button>` tags and insert their ids.
-3. `nbCodeToJs` is the template that will turn our Nim code into Javascript and we are capturing `labelId` and `buttonId` (Important that you capture all used variables defined outside the code block). `std/dom` is where many dom-manipulation functions are located.
+3. `nbJsFromCode` is the template that will turn our Nim code into Javascript and we are capturing `labelId` and `buttonId` (Important that you capture all used variables defined outside the code block). `std/dom` is where many dom-manipulation functions are located.
 4. We fetch the elements we emitted above by their ids. Remember that most javascript functions want `cstring`s!
 5. We create a variable `counter` to keep track of the counter and add the eventlistener to the `button` element. There we increase the counter and update the `innerHtml` of the `label`.
 

--- a/docsrc/index.nim
+++ b/docsrc/index.nim
@@ -86,9 +86,9 @@ in this repo:
 * [numerical]({docs}/numerical.html): example usage of NumericalNim (example of custom style, usage of latex)
 * [cheatsheet]({docs}/cheatsheet.html): markdown cheatsheet (example of a custom block, custom highlighting and a simple TOC)
 * [mostaccio]({docs}/mostaccio.html): examples of usage of nim-mustache and of dark mode.
-* [interactivity]({docs}/interactivity.html): shows the basic API of creating interactive elements using `nbCodeToJs`.
+* [interactivity]({docs}/interactivity.html): shows the basic API of creating interactive elements using `nbJsFromCode`.
 * [counter]({docs}/counters.html): shows how to create reusable interactive widgets by creating a counter button.
-* [caesar]({docs}/caesar.html): a Caesar cipher implemented using `nbCodeToJs` and `karax`.
+* [caesar]({docs}/caesar.html): a Caesar cipher implemented using `nbJsFromCode` and `karax`.
 
 
 elsewhere:
@@ -153,11 +153,11 @@ Currently most of the documentation on customization is given by the examples.
 See `src/nimib.nim` for examples on nimib blocks that are built using these two templates.
 
 * a `newId` proc is available for `nb: NbDoc` object and provides an incremental integer.
-  It can be used in some custom blocks (it is used in `nbCodeToJs` described below).
+  It can be used in some custom blocks (it is used in `nbJsFromCode` described below).
 
 ### interactivity using nim js backend
 
-Nimib can incorporate javascript code generated from nim code using template `nbCodeToJs`.
+Nimib can incorporate javascript code generated from nim code using template `nbJsFromCode`.
 It also provides a template `nbKaraxCode` to add code based on [karax](https://github.com/karaxnim/karax).
 
 See [interactivity]({docs}/interactivity.html) for an explanation of the api

--- a/docsrc/interactivity.nim
+++ b/docsrc/interactivity.nim
@@ -6,20 +6,20 @@ nbText: hlMd"""
 # Creating interactive components in Nimib
 
 Nimib can easily be used to create static content with `nbText` and `nbCode`, but did you know that you can create interactive
-content as well? And that you can do it all in Nim even! This can be achieved using either the `nbCodeToJs`-API or `nbKaraxCode`.
+content as well? And that you can do it all in Nim even! This can be achieved using either the `nbJsFromCode`-API or `nbKaraxCode`.
 They work by compiling Nim code into javascript and adding it to the resulting HTML file.
 This means that arbitrary Javascript can be written but also that Karax, which compiles to javascript, also can be used.
 
-## nbCodeToJsInit
+## nbJsFromCodeInit
 This is the fundamental API used for compiling Nim-snippets to javascript. It consists of three templates:
-- `nbCodeToJsInit` - Creates a new code script that further code can be added to later.
+- `nbJsFromCodeInit` - Creates a new code script that further code can be added to later.
 - `addCodeToJs` - Adds to an existing code script
 - `addToDocAsJs` - Takes the Nim code in a script and compiles it to javascript. 
 Here is a basic example:
 """
 
 nbCode:
-  let script = nbCodeToJsInit:
+  let script = nbJsFromCodeInit:
     echo "Hello world!"
   let x = 3.14
   script.addCodeToJs(x):
@@ -27,7 +27,7 @@ nbCode:
   ## Uncomment this line:
   ##script.addToDocAsJs()
 script.addToDocAsJs()
-nbCodeToJsShowSource("This is the complete script:")
+nbJsShowSource("This is the complete script:")
 
 
 nbText: hlMd"""
@@ -38,8 +38,8 @@ to be able to use it in the javascript. The code block will basically be copy-pa
 compiled into javascript. And `x` isn't defined there so we have to capture it. This is true for any variable that
 we want to use that is defined outside the script blocks.
 
-## nbCodeToJs
-This is basically a shorthand for running `nbCodeToJsInit` and `addToDocAsJs` in a single call:
+## nbJsFromCode
+This is basically a shorthand for running `nbJsFromCodeInit` and `addToDocAsJs` in a single call:
 ```nim
 let x = 3.14
 nbJsCode(x):
@@ -51,7 +51,7 @@ nbJsCode(x):
 If you want to write a component using karax this is the template for you!
 A normal karax program has the following structure:
 ```nim
-nbCodeToJs(rootId):
+nbJsFromCode(rootId):
   import karax / [kbase, karax, karaxdsl, vdom, compact, jstrutils, kdom]
 
   karaxCode  # some code, set up global variables for example

--- a/nimib.nimble
+++ b/nimib.nimble
@@ -41,6 +41,6 @@ task docs, "Build documentation":
   exec "nim r docsrc/interactivity.nim"
   exec "nim r docsrc/counters.nim"
   exec "nim r docsrc/caesar.nim"
-  when not defined(nimibDocsSkipPenguins):
-    exec "nim r docsrc/penguins.nim"
+  #when not defined(nimibDocsSkipPenguins):
+  #  exec "nim r docsrc/penguins.nim"
   exec "nimble readme"  

--- a/nimib.nimble
+++ b/nimib.nimble
@@ -15,7 +15,7 @@ requires "mustache >= 0.2.1"
 requires "toml_serialization >= 0.2.0"
 
 task docsdeps, "install dependendencies required for doc building":
-  exec "nimble -y install ggplotnim@0.5.2 numericalnim@0.6.1 nimoji nimpy karax@1.2.2"
+  exec "nimble -y install ggplotnim@0.5.3 numericalnim@0.6.1 nimoji nimpy karax@1.2.2"
 
 task test, "General tests":
   exec "nim r tests/tsources.nim"

--- a/nimib.nimble
+++ b/nimib.nimble
@@ -15,7 +15,7 @@ requires "mustache >= 0.2.1"
 requires "toml_serialization >= 0.2.0"
 
 task docsdeps, "install dependendencies required for doc building":
-  exec "nimble -y install ggplotnim@0.4.9 numericalnim@0.6.1 nimoji nimpy karax@1.2.2"
+  exec "nimble -y install ggplotnim@0.5.2 numericalnim@0.6.1 nimoji nimpy karax@1.2.2"
 
 task test, "General tests":
   exec "nim r tests/tsources.nim"
@@ -41,6 +41,6 @@ task docs, "Build documentation":
   exec "nim r docsrc/interactivity.nim"
   exec "nim r docsrc/counters.nim"
   exec "nim r docsrc/caesar.nim"
-  #when not defined(nimibDocsSkipPenguins):
-  #  exec "nim r docsrc/penguins.nim"
+  when not defined(nimibDocsSkipPenguins):
+    exec "nim r docsrc/penguins.nim"
   exec "nimble readme"  

--- a/src/nimib.nim
+++ b/src/nimib.nim
@@ -126,13 +126,6 @@ template nbRawOutput*(content: string) =
   newNbSlimBlock("nbRawOutput"):
     nb.blk.output = content
 
-
-#[ template nbCodeToJsInit*(args: varargs[untyped]): NbBlock =
-  let (code, originalCode) = nimToJsString(true, args)
-  var result = NbBlock(command: "nbCodeToJs", code: originalCode, context: newContext(searchDirs = @[], partials = nb.partials), output: "")
-  result.context["transformedCode"] = code
-  result ]#
-
 template nbJsFromStringInit*(body: string): NbBlock =
   var result = NbBlock(command: "nbCodeToJs", code: body, context: newContext(searchDirs = @[], partials = nb.partials), output: "")
   result.context["transformedCode"] = body
@@ -143,6 +136,9 @@ template nbJsFromCodeInit*(args: varargs[untyped]): NbBlock =
   var result = NbBlock(command: "nbCodeToJs", code: originalCode, context: newContext(searchDirs = @[], partials = nb.partials), output: "")
   result.context["transformedCode"] = code
   result
+
+template nbCodeToJsInit*(args: varargs[untyped]): NbBlock {.deprecated: "Use nbJsFromCodeInit or nbJsFromStringInit instead".} =
+  nbJsFromCodeInit(args)
 
 template addCodeToJs*(script: NbBlock, args: varargs[untyped]) =
   let (code, originalCode) = nimToJsString(false, args)
@@ -157,10 +153,6 @@ template addToDocAsJs*(script: NbBlock) =
   nb.blocks.add script
   nb.blk = script
 
-#template nbCodeToJs*(args: varargs[untyped]) =
-#  let script = nbCodeToJsInit(args)
-#  script.addToDocAsJs
-
 template nbJsFromString*(body: string) =
   let script = nbJsFromStringInit(body)
   script.addToDocAsJs
@@ -168,6 +160,9 @@ template nbJsFromString*(body: string) =
 template nbJsFromCode*(args: varargs[untyped]) =
   let script = nbJsFromCodeInit(args)
   script.addToDocAsJs
+
+template nbCodeToJs*(args: varargs[untyped]) {.deprecated: "Use nbJsFromCode or nbJsFromString instead".} =
+  nbJsFromCode(args)
 
 
 when moduleAvailable(karax/kbase):
@@ -180,6 +175,9 @@ template nbJsShowSource*(message: string = "") =
   nb.blk.context["js_show_nim_source"] = true
   if message.len > 0:
     nb.blk.context["js_show_nim_source_message"] = message
+
+template nbCodeToJsShowSource*(message: string = "") {.deprecated: "Use nbJsShowSource instead".} =
+  nbJsShowSource(message)
 
 
 template nbClearOutput*() =

--- a/src/nimib.nim
+++ b/src/nimib.nim
@@ -127,7 +127,18 @@ template nbRawOutput*(content: string) =
     nb.blk.output = content
 
 
-template nbCodeToJsInit*(args: varargs[untyped]): NbBlock =
+#[ template nbCodeToJsInit*(args: varargs[untyped]): NbBlock =
+  let (code, originalCode) = nimToJsString(true, args)
+  var result = NbBlock(command: "nbCodeToJs", code: originalCode, context: newContext(searchDirs = @[], partials = nb.partials), output: "")
+  result.context["transformedCode"] = code
+  result ]#
+
+template nbJsFromStringInit*(body: string): NbBlock =
+  var result = NbBlock(command: "nbCodeToJs", code: body, context: newContext(searchDirs = @[], partials = nb.partials), output: "")
+  result.context["transformedCode"] = body
+  result
+
+template nbJsFromCodeInit*(args: varargs[untyped]): NbBlock =
   let (code, originalCode) = nimToJsString(true, args)
   var result = NbBlock(command: "nbCodeToJs", code: originalCode, context: newContext(searchDirs = @[], partials = nb.partials), output: "")
   result.context["transformedCode"] = code
@@ -138,13 +149,24 @@ template addCodeToJs*(script: NbBlock, args: varargs[untyped]) =
   script.code &= "\n" & originalCode
   script.context["transformedCode"] = script.context["transformedCode"].vString & "\n" & code
 
+template addStringToJs*(script: NbBlock, body: string) =
+  script.code &= "\n" & body
+  script.context["transformedCode"] = script.context["transformedCode"].vString & "\n" & body
 
 template addToDocAsJs*(script: NbBlock) =
   nb.blocks.add script
   nb.blk = script
 
-template nbCodeToJs*(args: varargs[untyped]) =
-  let script = nbCodeToJsInit(args)
+#template nbCodeToJs*(args: varargs[untyped]) =
+#  let script = nbCodeToJsInit(args)
+#  script.addToDocAsJs
+
+template nbJsFromString*(body: string) =
+  let script = nbJsFromStringInit(body)
+  script.addToDocAsJs
+
+template nbJsFromCode*(args: varargs[untyped]) =
+  let script = nbJsFromCodeInit(args)
   script.addToDocAsJs
 
 
@@ -154,7 +176,7 @@ when moduleAvailable(karax/kbase):
     nbRawOutput: "<div id=\"" & rootId & "\"></div>"
     nbKaraxCodeBackend(rootId, args)
 
-template nbCodeToJsShowSource*(message: string = "") =
+template nbJsShowSource*(message: string = "") =
   nb.blk.context["js_show_nim_source"] = true
   if message.len > 0:
     nb.blk.context["js_show_nim_source_message"] = message

--- a/src/nimib/jsutils.nim
+++ b/src/nimib/jsutils.nim
@@ -37,6 +37,7 @@ proc gensymProcIterConverter(n: NimNode, replaceProcs: bool) =
     case n[i].kind
     of nnkProcDef, nnkIteratorDef, nnkConverterDef:
       if replaceProcs:
+        # add check for {.exportc.} here
         if n[i][0].kind == nnkPostfix: # foo*
           let oldIdent = n[i][0][1].strVal.nimIdentNormalize
           let newIdent = gensym(ident=oldIdent).repr.ident

--- a/src/nimib/jsutils.nim
+++ b/src/nimib/jsutils.nim
@@ -19,6 +19,7 @@ macro checkIsValidCode(n: untyped): untyped =
     else:
       false
 
+# remove this
 macro addValid(key: string, s: typed): untyped =
   # If it is valid we want it typed
   if key.strVal notin validCodeTable:

--- a/src/nimib/jsutils.nim
+++ b/src/nimib/jsutils.nim
@@ -167,7 +167,7 @@ macro nimToJsStringSecondStage*(key: static string, captureVars: varargs[typed])
     
 macro nimToJsString*(isNewScript: static bool, args: varargs[untyped]): untyped =
   if args.len == 0:
-    error("nbCodeToJs needs a code block to be passed", args)
+    error("nbJsFromCode needs a code block to be passed", args)
   
   # If new script, clear the table.
   if isNewScript:
@@ -230,6 +230,6 @@ macro nbKaraxCodeBackend*(rootId: untyped, args: varargs[untyped]) =
   callArgs.add captureVars
   callArgs.add newBody
 
-  let call = newCall(ident"nbCodeToJs", callArgs)
+  let call = newCall(ident"nbJsFromCode", callArgs)
 
   result = call

--- a/src/nimib/jsutils.nim
+++ b/src/nimib/jsutils.nim
@@ -210,11 +210,19 @@ macro nbKaraxCodeBackend*(rootId: untyped, args: varargs[untyped]) =
   let newBody = quote do:
     import karax / [kbase, karax, karaxdsl, vdom, compact, jstrutils, kdom]
 
+    var postRenderCallback: proc () = nil
+
+    template postRender(body: untyped) =
+      ## Must be called before karaxHtml!!!
+      proc tempProc () =
+        body
+      postRenderCallback = tempProc
+
     template karaxHtml(body: untyped) =
       proc createDom(): VNode =
         result = buildHtml(tdiv):
           body # html karax code
-      setRenderer(createDom, root=`rootId`.cstring)
+      setRenderer(createDom, root=`rootId`.cstring, clientPostRenderCallback = postRenderCallback)
 
     `body`
 

--- a/tests/tnimib.nim
+++ b/tests/tnimib.nim
@@ -196,7 +196,7 @@ when moduleAvailable(karax/kbase):
       check nb.blk.code.len > 0
       check nb.blk.context["transformedCode"].vString.len > 0
     
-    test "Interlaced nbJsFromCode":
+    #[ test "Interlaced nbJsFromCode": # failing because of #118
       template foo() =
         let script1 = nbJsFromCodeInit:
           let a = 1
@@ -213,4 +213,4 @@ when moduleAvailable(karax/kbase):
           let code = script.context["transformedCode"].vString # eg. "\nlet a_469764253 = 1\n\necho a_469764292"
           let splits = code.splitWhitespace() # @["let", "a_469764257", "=", "1", "echo", "a_469764296"]
           check splits[1] == splits[5]
-      foo()
+      foo() ]#

--- a/tests/tnimib.nim
+++ b/tests/tnimib.nim
@@ -195,3 +195,22 @@ when moduleAvailable(karax/kbase):
             text message
       check nb.blk.code.len > 0
       check nb.blk.context["transformedCode"].vString.len > 0
+    
+    test "Interlaced nbJsFromCode":
+      template foo() =
+        let script1 = nbJsFromCodeInit:
+          let a = 1
+        let script2 = nbJsFromCodeInit:
+          let b = 2
+        script1.addCodeToJs:
+          echo a
+        script2.addCodeToJs:
+          echo b
+
+        echo script1.context["transformedCode"]
+        echo script2.context["transformedCode"]
+        for script in [script1, script2]:
+          let code = script.context["transformedCode"].vString # eg. "\nlet a_469764253 = 1\n\necho a_469764292"
+          let splits = code.splitWhitespace() # @["let", "a_469764257", "=", "1", "echo", "a_469764296"]
+          check splits[1] == splits[5]
+      foo()

--- a/tests/tnimib.nim
+++ b/tests/tnimib.nim
@@ -186,6 +186,13 @@ when moduleAvailable(karax/kbase):
       check nb.blk.code.len > 0
       check nb.blk.context["transformedCode"].vString.len > 0
 
+    test "nbJsFromCode + exportc":
+      let script = nbJsFromCodeInit:
+        proc setup() {.exportc.} =
+          echo 1
+      script.addToDocAsJs
+      check "setup()" in nb.blk.context["transformedCode"].vString
+
     test "nbKaraxCode":
       let x = 3.14
       nbKaraxCode(x):

--- a/tests/tnimib.nim
+++ b/tests/tnimib.nim
@@ -151,9 +151,9 @@ print(a)
       check nb.blk.output == "[0, 2, 4]\n3.14\n"
 
 when moduleAvailable(karax/kbase):
-  suite "nbCodeToJs":
-    test "nbCodeToJs - string":
-      nbCodeToJs: hlNim"""
+  suite "nbJs":
+    test "nbJsFromString":
+      nbJsFromString: hlNim"""
   let a = 1
   echo a
   """
@@ -163,22 +163,22 @@ when moduleAvailable(karax/kbase):
   """
       check nb.blk.context["transformedCode"].vString.len > 0
 
-    test "nbCodeToJs - untyped":
-      nbCodeToJs:
+    test "nbJsFromCode":
+      nbJsFromCode:
         let a = 1
         echo a
       check nb.blk.code.len > 0
       check nb.blk.context["transformedCode"].vString.len > 0
 
-    test "nbCodeToJs - untyped, capture variable":
+    test "nbJsFromCode, capture variable":
       let a = 1
-      nbCodeToJs(a):
+      nbJsFromCode(a):
         echo a
       check nb.blk.code.len > 0
       check nb.blk.context["transformedCode"].vString.len > 0
 
-    test "nbCodeToJsInit + addCodeToJs":
-      let script = nbCodeToJsInit:
+    test "nbJsFromCodeInit + addCodeToJs":
+      let script = nbJsFromCodeInit:
         let a = 1
       script.addCodeToJs:
         echo a


### PR DESCRIPTION
Fixes #122, ~~118~~, #124, #127

- [x] Separate untyped and string versions of `nbCodeToJs` (the body doesn't have to be type-checked anymore)
- [x] Rename nbCodeToJs to nbJsFromCode and nbJsFromString
- [x] Respect `{.exportc.}` when mangling names
- [ ] ~~Use separate mangling table for each script~~
- [x] nbKaraxCode postRender template