### PR TITLE
deprecate nbRawOutput for nbRawHtml and bump to 0.3.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,11 +9,15 @@ When contributing a fix, feature or example please add a new line to briefly exp
 
 ## 0.3.x
 
+* _add next change here_
+
+## 0.3.1
+
 * fix "Did not parse stylesheet at 'https://unpkg.com/normalize.css/' in strict mode" (#120)
 * Split untyped and string versions of `nbCodeToJs` into `nbJsFromCode` and `nbJsFromString`. Same for `nbCodeToJsInit` → `nbJsFromCodeInit`, `nbJsFromStringInit` (#125)
 * Add `postRender` template to `nbKaraxCode` (#125)
 * `nbJsFromCode` now respects `exportc` pragma (#125)
-* _add next change here_
+* rename `rawOutput` (deprecated) to `rawHtml`
 
 ## 0.3 "Block Maker" (July 2022)
 

--- a/nimib.nimble
+++ b/nimib.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.3.0"
+version       = "0.3.1"
 author        = "Pietro Peterlongo"
 description   = "nimib 🐳 - nim 👑 driven ⛵ publishing ✍"
 license       = "MIT"

--- a/src/nimib.nim
+++ b/src/nimib.nim
@@ -122,8 +122,11 @@ when moduleAvailable(nimpy):
         captureStdout(nb.blk.output):
           discard nbPythonBuiltins.exec(pythonStr)
 
-template nbRawOutput*(content: string) =
-  newNbSlimBlock("nbRawOutput"):
+template nbRawOutput*(content: string) {.deprecated: "Use nbRawHtml instead".} = 
+  nbRawHtml(content)
+
+template nbRawHtml*(content: string) =
+  newNbSlimBlock("nbRawHtml"):
     nb.blk.output = content
 
 template nbJsFromStringInit*(body: string): NbBlock =

--- a/src/nimib/renders.nim
+++ b/src/nimib/renders.nim
@@ -38,7 +38,7 @@ proc useHtmlBackend*(doc: var NbDoc) =
 <img src="{{url}}" alt="{{caption}}">
 <figcaption>{{caption}}</figcaption>
 </figure>"""
-  doc.partials["nbRawOutput"] = "{{&output}}"
+  doc.partials["nbRawHtml"] = "{{&output}}"
   doc.partials["nbPython"] = """
 <pre><code class="python hljs">{{&code}}</code></pre>
 {{#output}}<pre><samp>{{&output}}</samp></pre>{{/output}}

--- a/tests/tnimib.nim
+++ b/tests/tnimib.nim
@@ -100,14 +100,14 @@ suite "nbCode":
     check nb.blk.code == "echo \"hi\""
     check nb.blk.output == "hi\n"
 
-suite "nbRawOutput":
+suite "nbRawHtml":
   test "pure text":
-    nbRawOutput: "Hello world!"
+    nbRawHtml: "Hello world!"
     check nb.blk.code == ""
     check nb.blk.output == "Hello world!"
   
   test "html tags":
-    nbRawOutput: "<div> <span> div-span </span> </div>"
+    nbRawHtml: "<div> <span> div-span </span> </div>"
     check nb.blk.code == ""
     check nb.blk.output == "<div> <span> div-span </span> </div>"
 
@@ -115,9 +115,9 @@ suite "nbRawOutput":
     # codeAsInSource can't read the correct line if block is used inside a template
     # check that readCode is having effect and preventing the reading of code.
     template slide(body: untyped) =
-      nbRawOutput: "<slide>"
+      nbRawHtml: "<slide>"
       body
-      nbRawOutput: "</slide>"
+      nbRawHtml: "</slide>"
     
     slide:
       check nb.blk.code == ""


### PR DESCRIPTION
not sure if we discussed it @HugoGranstrom but I had in the back of mind also to deprecate `nbRawOutput` for a new `nbRawHtml` which does the same. `nbRawHtml` is the name that best describe the usage (while `nbRawOutput` is more about implementation detail of the block).

this PR also completes changelog for 0.3.1 and bumps nimble version, making it ready to release the 0.3.1.