### PR TITLE
Fix stdout windows issue

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ When contributing a fix, feature or example please add a new line to briefly exp
 ## 0.3.x
 
 * Add `hlHtml` and `hlHtml` to nimiBoost
+* fix rarely occuring issue of terminal output not being captured (windows only, see example in https://github.com/pietroppeter/nimib/pull/132)
 * _add next change here_
 
 ## 0.3.1

--- a/src/nimib.nim
+++ b/src/nimib.nim
@@ -73,7 +73,6 @@ template nbCode*(body: untyped) =
   newNbCodeBlock("nbCode", body):
     captureStdout(nb.blk.output):
       body
-      flushFile stdout
 
 template nbCodeInBlock*(body: untyped): untyped =
   block:

--- a/src/nimib.nim
+++ b/src/nimib.nim
@@ -73,6 +73,7 @@ template nbCode*(body: untyped) =
   newNbCodeBlock("nbCode", body):
     captureStdout(nb.blk.output):
       body
+      flushFile stdout
 
 template nbCodeInBlock*(body: untyped): untyped =
   block:

--- a/src/nimib/capture.nim
+++ b/src/nimib/capture.nim
@@ -20,6 +20,7 @@ template captureStdout*(ident: untyped, body: untyped) =
   discard dup2(tmpFileFd, stdoutFileno)  # writing to stdoutFileno now writes to tmpFile
 
   body
+  flushFile stdout
 
   # before reading tmpFile, flush and close
   tmpFile.flushFile()  


### PR DESCRIPTION
in the following example the terminal output is not captured on my windows machine (works on my mac machine). The fix in this PR (or uncommenting the flushfile line) makes it work for the windows machine:

```nim
import QRgen
import nimib

nbInit
nbText: "playing with  [QRgen](https://github.com/aruZeta/QRgen)"
nbCode:
  let myQR = newQr("https://github.com/pietroppeter/nimconf22-nimib")
  myQR.printTerminal
  #flushFile stdout  # needed on windows not on mac
nbSave
```

honestly I am not sure why this fix is needed, I just tried it because I had a hunch and it worked...

@HugoGranstrom: with latest commit I was able to make it work in captureStdout (very evident why... ;)), so no need to  document this anywhere, I guess.

I will add a line to changelog once I merge your changelog line from hlHtml PR (indeed our current changelog can run into conflicts, we could consider using something like https://github.com/iffy/changer)