### PR TITLE
reduced vertical spacing in default theme

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ When contributing a fix, feature or example please add a new line to briefly exp
 
 * Add `hlHtml` and `hlHtml` to nimiBoost
 * fix rarely occuring issue of terminal output not being captured (windows only, see example in https://github.com/pietroppeter/nimib/pull/132)
+* compress line height in nbCode output (using class `nb-output`), see #133
 * _add next change here_
 
 ## 0.3.1

--- a/src/nimib/renders.nim
+++ b/src/nimib/renders.nim
@@ -33,7 +33,7 @@ proc useHtmlBackend*(doc: var NbDoc) =
 {{>nbCodeSource}}
 {{>nbCodeOutput}}"""
   doc.partials["nbCodeSource"] = "<pre><code class=\"nim hljs\">{{&codeHighlighted}}</code></pre>"
-  doc.partials["nbCodeOutput"] = "{{#output}}<pre><samp>{{output}}</samp></pre>{{/output}}"
+  doc.partials["nbCodeOutput"] = """{{#output}}<pre class="nb-output"><samp>{{output}}</samp></pre>{{/output}}"""
   doc.partials["nbImage"] = """<figure>
 <img src="{{url}}" alt="{{caption}}">
 <figcaption>{{caption}}</figcaption>

--- a/src/nimib/themes.nim
+++ b/src/nimib/themes.nim
@@ -64,6 +64,10 @@ button.nb-small {
 section#source {
   display:none
 }
+
+body {
+  line-height: 1.15;
+}
 </style>"""
 
 const header* = """

--- a/src/nimib/themes.nim
+++ b/src/nimib/themes.nim
@@ -65,7 +65,7 @@ section#source {
   display:none
 }
 
-body {
+.nb-output {
   line-height: 1.15;
 }
 </style>"""

--- a/tests/trenders.nim
+++ b/tests/trenders.nim
@@ -16,4 +16,4 @@ suite "render (block), html default backend":
   test "nbCode with output":
     nbCode: echo "hi"
     check nb.render(nb.blk).strip == """
-<pre><code class="nim hljs"><span class="hljs-keyword">echo</span> <span class="hljs-string">&quot;hi&quot;</span></code></pre><pre><samp>hi</samp></pre>"""
+<pre><code class="nim hljs"><span class="hljs-keyword">echo</span> <span class="hljs-string">&quot;hi&quot;</span></code></pre><pre class="nb-output"><samp>hi</samp></pre>"""


### PR DESCRIPTION
this was stimulated from this particular example, where I realized that - at least for terminal output - the vertical spacing is not ideal.

before:
![image](https://user-images.githubusercontent.com/4997234/190865689-6ed69882-6e46-486a-9426-eb84f86ebcff.png)

after:
![image](https://user-images.githubusercontent.com/4997234/190865705-55f6fd7c-b71a-4d75-a0b7-64134752fc01.png)

in the current fix instead of just fixing the terminal output the vertical spacing is reduced everywhere (in a body css selector in used in default theme). Not sure if this is welcome or not (it helps packing more content vertically, it might decrease readability). I want to have a look on how this would look in nimib documentation and then decide if I want to restrict it only on terminal output (but I would need to learn the css selector that makes it work).

as a reminder, when this is ready it will need a:

- [ ] changelog line