### PR TITLE
gensym captured variables that  haven't already been gensymed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ When contributing a fix, feature or example please add a new line to briefly exp
 * Add `hlHtml` and `hlHtml` to nimiBoost
 * fix rarely occuring issue of terminal output not being captured (windows only, see example in https://github.com/pietroppeter/nimib/pull/132)
 * compress line height in nbCode output (using class `nb-output`), see #133
+* Fixed a case when capturing a global in `nbJsFromCode` didn't gensym the symbols, causing the same variable names in the generated code. #136
 * _add next change here_
 
 ## 0.3.1

--- a/src/nimib/jsutils.nim
+++ b/src/nimib/jsutils.nim
@@ -136,9 +136,18 @@ proc genCapturedAssignment(capturedVariables, capturedTypes: seq[NimNode]): tupl
       import std/json
     for (cap, capType) in zip(capturedVariables, capturedTypes):
       let placeholder = gensym(ident="placeholder")
+      var newSym: NimNode
+      if "`gensym" notin cap.strVal:
+        newSym = gensym(NimSymKind.nskLet, ident=cap.strVal)
+        # add to tab[cap] = cap.gensym?
+        tabMapIdents[cap.strVal.nimIdentNormalize] = newSym.repr.ident
+      else:
+        newSym = cap
+      echo "In: ", cap.repr, " Out: ", newSym.repr
       result.placeholders.add placeholder
       result.code.add quote do:
-        let `cap` = parseJson(`placeholder`).to(`capType`)
+        let `newSym` = parseJson(`placeholder`).to(`capType`) # we must gensym `cap` as well!
+      
 
 macro nimToJsStringSecondStage*(key: static string, captureVars: varargs[typed]): untyped =
   let captureVars = toSeq(captureVars)

--- a/src/nimib/jsutils.nim
+++ b/src/nimib/jsutils.nim
@@ -115,12 +115,10 @@ proc degensymAst(n: NimNode, removeGensym = false) =
             newSym = gensym(ident=newStr).repr.ident
             tabMapIdents[newStr] = newSym
         n[i] = newSym
-        echo "Swapped ", str, " for ", newSym.repr
     of nnkPragmaExpr:
       let identifier = n[i][0]
       let pragmas = n[i][1]
       if pragmas.isPragmaExportc: # varName {.exportc.}
-        echo "Saved: ", identifier.repr, " -> ", identifier.strVal.split("`gensym")[0].ident.repr
         n[i][0] = identifier.strVal.split("`gensym")[0].ident
       else:
         degensymAst(identifier, removeGensym)
@@ -143,7 +141,6 @@ proc genCapturedAssignment(capturedVariables, capturedTypes: seq[NimNode]): tupl
         tabMapIdents[cap.strVal.nimIdentNormalize] = newSym.repr.ident
       else:
         newSym = cap
-      echo "In: ", cap.repr, " Out: ", newSym.repr
       result.placeholders.add placeholder
       result.code.add quote do:
         let `newSym` = parseJson(`placeholder`).to(`capType`) # we must gensym `cap` as well!


### PR DESCRIPTION
If I tried to capture a global variable in `nbJsFromCode` inside a template, it didn't gensym the variable correctly (because it wasn't gensym'd by the template, the code didn't know to gensym it itself). This seems to fix it, though. 