### PR TITLE
add nbCodeDisplay and nbCodeAnd

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,15 @@ When contributing a fix, feature or example please add a new line to briefly exp
 ## 0.3.x
 * _add next change here_
 
+## 0.3.4
+
+* added `nbCodeDisplay` and `nbCodeAnd` (#158).
+  They provide an easy way to:
+    - display code in `nbJsFromCode` and friends
+    - run code both in js and c backend
+  They are also generic templates that can be used with other templates
+  and do not depend on any specificities of `nbJsFromCode` templates.
+
 ## 0.3.3
 
 * Refactored nbJs (#148)

--- a/docsrc/interactivity.nim
+++ b/docsrc/interactivity.nim
@@ -163,6 +163,36 @@ karaxExample()
 nbText: "Another example on how to use `nbKaraxCode` can be found in the [caesar document](./caesar.html) by clicking the `Show Source` button at the bottom."
 
 nbText: hlMd"""
+## nbCodeDisplay and nbCodeAnd
+
+We introduce in this section two generic templates that can be useful when used with the
+templates of `nbJsFromCode` family.
+
+### Display code in nbJsFromCode with nbCodeDisplay
+
+If you wish to display the code used in one of `nbJsFromCode`, `nbJsFromCodeInBlock`, `nbJsFromCodeGlobal`
+you can use `nbCodeDisplay` (which can be used in general with any template that does not show code by itself):
+"""
+nimibCode:
+  nbCodeDisplay(nbJsFromCodeInBlock):
+    echo "hi nbCodeDisplay"
+nbText: hlMd"""
+
+Note that in this same document we gave examples of two other methods
+to show code:
+
+- `nimibCode`: to show the code as you would use it in a nimib file
+- `nbCode` + template: create a template (e.g. `karaxExample`) inside a `nbCode` and call the template later.
+
+### Running the same code with both c and js backends using nbCodeAnd
+
+If you want to run some code both in C and js backends, you can use `nbCodeAnd`:
+"""
+nimibCode:
+  nbCodeAnd(nbJsFromCodeInBlock):
+    echo "hi nbCodeAnd"
+
+nbText: hlMd"""
 ## Internal workings
 ### nbJsFromCode
 Any code defined in `nbJsFromCode`, `nbJsFromCodeInBlock` and `nbJsFromCodeGlobal` will be pasted into a common file.

--- a/nimib.nimble
+++ b/nimib.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.3.3"
+version       = "0.3.4"
 author        = "Pietro Peterlongo"
 description   = "nimib 🐳 - nim 👑 driven ⛵ publishing ✍"
 license       = "MIT"

--- a/src/nimib.nim
+++ b/src/nimib.nim
@@ -197,6 +197,11 @@ template nbJsShowSource*(message: string = "") =
 template nbCodeToJsShowSource*(message: string = "") {.deprecated: "Use nbJsShowSource instead".} =
   nbJsShowSource(message)
 
+template nbCodeDisplay*(tmplCall: untyped, body: untyped) =
+  newNbCodeBlock("nbCode", body):
+    discard
+  tmplCall:
+    body
 
 template nbClearOutput*() =
   if not nb.blk.isNil:

--- a/src/nimib.nim
+++ b/src/nimib.nim
@@ -189,12 +189,12 @@ when moduleAvailable(karax/kbase):
     nbRawHtml: "<div id=\"" & rootId & "\"></div>"
     nbKaraxCodeBackend(rootId, args)
 
-template nbJsShowSource*(message: string = "") =
+template nbJsShowSource*(message: string = "") {.deprecated: "Use nbCodeDisplay instead".} =
   nb.blk.context["js_show_nim_source"] = true
   if message.len > 0:
     nb.blk.context["js_show_nim_source_message"] = message
 
-template nbCodeToJsShowSource*(message: string = "") {.deprecated: "Use nbJsShowSource instead".} =
+template nbCodeToJsShowSource*(message: string = "") {.deprecated: "Use nbCodeDisplay instead".} =
   nbJsShowSource(message)
 
 template nbCodeDisplay*(tmplCall: untyped, body: untyped) =

--- a/src/nimib.nim
+++ b/src/nimib.nim
@@ -198,8 +198,16 @@ template nbCodeToJsShowSource*(message: string = "") {.deprecated: "Use nbJsShow
   nbJsShowSource(message)
 
 template nbCodeDisplay*(tmplCall: untyped, body: untyped) =
+  ## display codes used in a template (e.g. nbJsFromCode) after the template call
+  tmplCall:
+    body
   newNbCodeBlock("nbCode", body):
     discard
+
+template nbCodeAnd*(tmplCall: untyped, body: untyped) =
+  ## can be used to run code both in c and js backends (e.g. nbCodeAnd(nbJsFromCode))
+  nbCode: # this should work because template name starts with nbCode
+    body
   tmplCall:
     body
 

--- a/tests/tnimib.nim
+++ b/tests/tnimib.nim
@@ -209,3 +209,30 @@ when moduleAvailable(karax/kbase):
             text message
       check nb.blk.code.len > 0
       check nb.blk.context["transformedCode"].vString.len > 0
+
+    test "nbCodeDisplay":
+      nbCodeDisplay(nbJsFromCode):
+        import p5
+        echo "hi p5"
+        draw:
+          ellipse(mouseX, mouseY, 20)
+      check nb.blocks[^1].command == "nbCode"
+      check nb.blocks[^2].command == "nbJsFromCode"
+      check nb.blocks[^2].context["transformedCode"].vString.len > 0
+      check "ellipse(mouseX, mouseY, 20)" in nb.blocks[^2].context["transformedCode"].vString
+      when defined(nimibCodeFromAst):
+        check nb.blocks[^1].code.startsWith("import\n  p5")
+      else:
+        check nb.blocks[^1].code.startsWith("import p5")
+      check nb.blocks[^1].output == ""
+
+    test "nbCodeAnd":
+      nbCodeAnd(nbJsFromCode):
+        let you = "me"
+        echo "hi ", you
+      check nb.blocks[^2].command == "nbCode"
+      check nb.blocks[^1].command == "nbJsFromCode"
+      check nb.blocks[^1].context["transformedCode"].vString.len > 0
+      check "you = \"me\"" in nb.blocks[^1].context["transformedCode"].vString
+      check nb.blocks[^2].code.startsWith("let you =")
+      check nb.blocks[^2].output == "hi me\n"


### PR DESCRIPTION
fix #154, instead of creating a `nbJsFromCodeDisplay` as suggested there (I would need also the Global, InBlock and possibly other variations), I only add this template. It will not work with templates that have more than one body argument (so it will not work directly with the Js templates when capturing variables, but you can wrap that call in a template with single body argument). Seems an easy enough change. Already using it in p5nim, choosing to go with nbCode after the template call (inverse would have been fine too).

I am also adding a `nbCodeAnd` to execute code in c backend **and** js backend (when applied to `nbJsFromCode`).
Both are documented in `interactivity.nim` because it makes sense to mention them there but they are generic.

I have already started using `nbCodeDisplay` in p5nim (see https://github.com/pietroppeter/p5nim/pull/9) and I plan to use `nbCodeAnd` in adventofnim (to solve a puzzle and use the same structure to visualize it with p5).

- [x] add nbCodeDisplay template
- [x] add nbCodeDisplay template
- [x] use it and document it (in interactivity.nim)
- [x] add tests for both
- [x] line in changelog
- [x] bump to 0.3.4 