### PR TITLE
Adding devel to CI, fix #161, fix #149

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,18 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        nim:
+          - '1.6.x'
+          - 'stable'
+          - 'devel'
+    name: Nim ${{ matrix.nim }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: jiro4989/setup-nim-action@v1.3.15
+      - uses: actions/checkout@v3
+      - uses: jiro4989/setup-nim-action@v1.4.3
         with:
-          nim-version: '1.6.x'
+          nim-version: ${{ matrix.nim }}
       - run: nimble -y install
       - run: nimble docsdeps
       - run: nimble test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
           - '1.6.x'
           - 'stable'
           - 'devel'
+      fail-fast: false
     name: Nim ${{ matrix.nim }}
     steps:
       - uses: actions/checkout@v3

--- a/nimib.nimble
+++ b/nimib.nimble
@@ -12,7 +12,8 @@ requires "nim >= 1.4.0"
 requires "tempfile >= 0.1.6"
 requires "markdown >= 0.8.1"
 requires "mustache >= 0.2.1"
-requires "toml_serialization >= 0.2.0"
+requires "parsetoml >= 0.7.0"
+requires "jsony >= 1.1.5"
 
 task docsdeps, "install dependendencies required for doc building":
   exec "nimble -y install ggplotnim@0.5.3 numericalnim@0.6.1 nimoji nimpy karax@1.2.2"

--- a/nimib.nimble
+++ b/nimib.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.3.5"
+version       = "0.3.6"
 author        = "Pietro Peterlongo & Hugo Granström"
 description   = "nimib 🐳 - nim 👑 driven ⛵ publishing ✍"
 license       = "MIT"

--- a/src/nimib/sources.nim
+++ b/src/nimib/sources.nim
@@ -151,6 +151,9 @@ macro getCodeAsInSource*(source: string, command: static string, body: untyped):
   let endPos = finishPos(body)
   let endFilename = endPos.filename.newLit
 
+  let endPosLit = endPos.newLit
+  let startPosLit = startPos.newLit
+
   result = quote do:
     if `filename` notin nb.sourceFiles:
       nb.sourceFiles[`filename`] = readFile(`filename`)
@@ -160,4 +163,4 @@ macro getCodeAsInSource*(source: string, command: static string, body: untyped):
     If you want to mix code from different files in nbCode, use -d:nimibCodeFromAst instead. 
     If you are not mixing code from different files, please open an issue on nimib's Github with a minimal reproducible example."""
 
-    getCodeBlock(nb.sourceFiles[`filename`], `command`, `startPos`, `endPos`)
+    getCodeBlock(nb.sourceFiles[`filename`], `command`, `startPosLit`, `endPosLit`)


### PR DESCRIPTION
I am adding both stable (that will become 2.x soon) and devel (which is candidate for 2.x). Also update versions of cache and setup-nim-action.

Done to check if recent toml fix makes nimib works in 2.0rc

We could also decide to expand the test matrix to multiple os.

fix #161 and #149