### PR TITLE
Change toml lib + fix macro bug on devel

### DIFF
--- a/nimib.nimble
+++ b/nimib.nimble
@@ -13,6 +13,7 @@ requires "tempfile >= 0.1.6"
 requires "markdown >= 0.8.1"
 requires "mustache >= 0.2.1"
 requires "parsetoml >= 0.7.0"
+requires "jsony >= 1.1.5"
 
 task docsdeps, "install dependendencies required for doc building":
   exec "nimble -y install ggplotnim@0.5.3 numericalnim@0.6.1 nimoji nimpy karax@1.2.2"

--- a/nimib.nimble
+++ b/nimib.nimble
@@ -12,7 +12,7 @@ requires "nim >= 1.4.0"
 requires "tempfile >= 0.1.6"
 requires "markdown >= 0.8.1"
 requires "mustache >= 0.2.1"
-requires "toml_serialization >= 0.2.0"
+requires "parsetoml >= 0.7.0"
 
 task docsdeps, "install dependendencies required for doc building":
   exec "nimble -y install ggplotnim@0.5.3 numericalnim@0.6.1 nimoji nimpy karax@1.2.2"

--- a/src/nimib/config.nim
+++ b/src/nimib/config.nim
@@ -1,4 +1,4 @@
-import types, os, toml_serialization
+import types, parsetoml, std / [json, os, math, sequtils]
 
 proc hasCfg*(doc: var NbDoc): bool = doc.cfgDir.string != ""
 
@@ -13,6 +13,72 @@ proc optOverride*(doc: var NbDoc) =
   if doc.options.homeDir != "":
     doc.cfg.homeDir = doc.options.homeDir
 
+
+proc customToJson*(table: parsetoml.TomlTableRef): JsonNode
+
+proc customToJson*(value: parsetoml.TomlValueRef): JsonNode =
+  ## Converts a TOML value to a JSON node. This uses the format specified in
+  ## the validation suite for it's output:
+  ## https://github.com/BurntSushi/toml-test#example-json-encoding
+  case value.kind:
+    of TomlValueKind.Int:
+      %* value.intVal
+    of TomlValueKind.Float:
+      if classify(value.floatVal) == fcNan:
+        if value.forcedSign != Pos:
+          %* value.floatVal
+        else:
+          %* value.floatVal
+      else:
+        %* value.floatVal
+    of TomlValueKind.Bool:
+      %* $value.boolVal
+    of TomlValueKind.Datetime:
+      if value.dateTimeVal.shift == false:
+        %* value.dateTimeVal
+      else:
+        %* value.dateTimeVal
+    of TomlValueKind.Date:
+      %* value.dateVal
+    of TomlValueKind.Time:
+      %* value.timeVal
+    of TomlValueKind.String:
+      %* value.stringVal
+    of TomlValueKind.Array:
+      if value.arrayVal.len == 0:
+        when defined(newtestsuite):
+          %[]
+        else:
+          %* []
+      elif value.arrayVal[0].kind == TomlValueKind.Table:
+        %value.arrayVal.map(customToJson)
+      else:
+        when defined(newtestsuite):
+          %*value.arrayVal.map(customToJson)
+        else:
+          %* value.arrayVal.map(customToJson)
+    of TomlValueKind.Table:
+      value.tableVal.customToJson()
+    of TomlValueKind.None:
+      %*{"type": "ERROR"}
+
+proc customToJson*(table: parsetoml.TomlTableRef): JsonNode =
+  ## Converts a TOML table to a JSON node. This uses the format specified in
+  ## the validation suite for it's output:
+  ## https://github.com/BurntSushi/toml-test#example-json-encoding
+  result = newJObject()
+  for key, value in pairs(table):
+    result[key] = value.customToJson
+
+
+proc loadTomlSection*[T](content, section: string, _: typedesc[T]): T =
+  let toml = parsetoml.parseString(content)
+  result = T()
+  if section in toml:
+    echo toml[section].toJson()
+    echo toml[section].customToJson()
+    result = toml[section].customToJson().to(T)
+
 proc loadNimibCfg*(cfgName: string): tuple[found: bool, dir: AbsoluteDir, raw: string, nb: NbConfig] =
   for dir in parentDirs(getCurrentDir()):
     if fileExists(dir / cfgName):
@@ -22,7 +88,7 @@ proc loadNimibCfg*(cfgName: string): tuple[found: bool, dir: AbsoluteDir, raw: s
       break
   if result.found:
     result.raw = readFile(result.dir.string / cfgName)
-    result.nb = Toml.decode(result.raw, NbConfig, "nimib")
+    result.nb = loadTomlSection(result.raw, "nimib", NbConfig)
 
 proc loadCfg*(doc: var NbDoc) =
   if not doc.options.skipCfg:

--- a/src/nimib/config.nim
+++ b/src/nimib/config.nim
@@ -1,4 +1,4 @@
-import types, parsetoml, std / [json, os, math, sequtils]
+import types, parsetoml, jsony, std / [json, os, math, sequtils]
 
 proc hasCfg*(doc: var NbDoc): bool = doc.cfgDir.string != ""
 
@@ -69,7 +69,7 @@ proc loadTomlSection*[T](content, section: string, _: typedesc[T]): T =
   let toml = parsetoml.parseString(content)
   result = T()
   if section in toml:
-    result = toml[section].customToJson().to(T)
+    result = ($toml[section].customToJson()).fromJson(T)
 
 proc loadNimibCfg*(cfgName: string): tuple[found: bool, dir: AbsoluteDir, raw: string, nb: NbConfig] =
   for dir in parentDirs(getCurrentDir()):

--- a/src/nimib/config.nim
+++ b/src/nimib/config.nim
@@ -17,9 +17,6 @@ proc optOverride*(doc: var NbDoc) =
 proc customToJson*(table: parsetoml.TomlTableRef): JsonNode
 
 proc customToJson*(value: parsetoml.TomlValueRef): JsonNode =
-  ## Converts a TOML value to a JSON node. This uses the format specified in
-  ## the validation suite for it's output:
-  ## https://github.com/BurntSushi/toml-test#example-json-encoding
   case value.kind:
     of TomlValueKind.Int:
       %* value.intVal
@@ -63,9 +60,6 @@ proc customToJson*(value: parsetoml.TomlValueRef): JsonNode =
       %*{"type": "ERROR"}
 
 proc customToJson*(table: parsetoml.TomlTableRef): JsonNode =
-  ## Converts a TOML table to a JSON node. This uses the format specified in
-  ## the validation suite for it's output:
-  ## https://github.com/BurntSushi/toml-test#example-json-encoding
   result = newJObject()
   for key, value in pairs(table):
     result[key] = value.customToJson
@@ -75,8 +69,6 @@ proc loadTomlSection*[T](content, section: string, _: typedesc[T]): T =
   let toml = parsetoml.parseString(content)
   result = T()
   if section in toml:
-    echo toml[section].toJson()
-    echo toml[section].customToJson()
     result = toml[section].customToJson().to(T)
 
 proc loadNimibCfg*(cfgName: string): tuple[found: bool, dir: AbsoluteDir, raw: string, nb: NbConfig] =

--- a/src/nimib/sources.nim
+++ b/src/nimib/sources.nim
@@ -151,6 +151,9 @@ macro getCodeAsInSource*(source: string, command: static string, body: untyped):
   let endPos = finishPos(body)
   let endFilename = endPos.filename.newLit
 
+  let endPosLit = endPos.newLit
+  let startPosLit = startPos.newLit
+
   result = quote do:
     if `filename` notin nb.sourceFiles:
       nb.sourceFiles[`filename`] = readFile(`filename`)
@@ -160,4 +163,4 @@ macro getCodeAsInSource*(source: string, command: static string, body: untyped):
     If you want to mix code from different files in nbCode, use -d:nimibCodeFromAst instead. 
     If you are not mixing code from different files, please open an issue on nimib's Github with a minimal reproducible example."""
 
-    getCodeBlock(nb.sourceFiles[`filename`], `command`, `startPos`, `endPos`)
+    getCodeBlock(nb.sourceFiles[`filename`], `command`, `startPosLit`, `endPosLit`)


### PR DESCRIPTION
- Fixes the orc bug on #169 
- Changes the toml parsing library to [parsetoml](https://github.com/NimParsers/parsetoml) which should make nimib run on orc finally. I had to do some workarounds though, like making my own `customToJson` proc to get the correct JSON for `std / json` to be able to parse it correctly into a `NbConfig`. 