### PR TITLE
remove export escapeTag

### DIFF
--- a/src/nimib/renders.nim
+++ b/src/nimib/renders.nim
@@ -1,6 +1,6 @@
 import std / [strutils, tables, sugar, os, strformat, sequtils]
 import ./types, ./jsutils, markdown, mustache
-export escapeTag # where is this used? why do I export? a better solution is to use xmlEncode
+
 import highlight
 import mustachepkg/values
 


### PR DESCRIPTION
[nim-markdown](https://github.com/soasme/nim-markdown)'s latest release removed the export of `escapeTag` so this causes compile errors now. This should be merged quickly and a new release be tagged as all nimib code has this problem right now!