### PR TITLE
Fix special chars escaped by the markdown renderer, close #159

### DIFF
--- a/src/nimib/renders.nim
+++ b/src/nimib/renders.nim
@@ -88,7 +88,7 @@ proc useMdBackend*(doc: var NbDoc) =
   doc.partials["nbImage"] = """
 ![{{&caption}}]({{&url}})
 
-**Figure:** {{caption}}
+**Figure:** {{&caption}}
 """
   doc.partials["nbPython"] = """
 ```python

--- a/src/nimib/renders.nim
+++ b/src/nimib/renders.nim
@@ -72,21 +72,21 @@ proc useMdBackend*(doc: var NbDoc) =
   doc.partials["nbCodeSource"] = """
 
 ```nim
-{{code}}
+{{&code}}
 ```
 
 """
   doc.partials["nbCodeOutput"] = """{{#output}}
 
 ```
-{{output}}
+{{&output}}
 ```
 
 {{/output}}
 """
   doc.partials["nimibCode"] = doc.partials["nbCode"]
   doc.partials["nbImage"] = """
-![{{caption}}]({{url}})
+![{{&caption}}]({{&url}})
 
 **Figure:** {{caption}}
 """

--- a/tests/trenders.nim
+++ b/tests/trenders.nim
@@ -17,3 +17,44 @@ suite "render (block), html default backend":
     nbCode: echo "hi"
     check nb.render(nb.blk).strip == """
 <pre><code class="nohighlight hljs nim"><span class="hljs-keyword">echo</span> <span class="hljs-string">&quot;hi&quot;</span></code></pre><pre class="nb-output">hi</pre>"""
+
+# switch to markdown backend
+useMdBackend nb
+
+suite "render (block), markdown backend":
+  test "nbText":
+    nbText: "hi"
+    check nb.render(nb.blk) == "hi"
+
+  test "nbCode without output":
+    nbCode: discard
+    check nb.render(nb.blk) == """
+
+```nim
+discard
+```
+
+"""
+
+  test "nbCode with output":
+    nbCode: echo "hi"
+    check nb.render(nb.blk) == """
+
+```nim
+echo "hi"
+```
+
+
+```
+hi
+```
+
+"""
+
+  test "nbImage with caption":
+    nbImage("https://nim-lang.org/assets/img/logo_bw.png", "nim-lang.org favicon")
+    check nb.render(nb.blk) == """
+![nim-lang.org favicon](https://nim-lang.org/assets/img/logo_bw.png)
+
+**Figure:** nim-lang.org favicon
+"""


### PR DESCRIPTION
Implements the fix described [here](https://github.com/pietroppeter/nimib/issues/159#issuecomment-1333710562). Also adds tests for markdown rendering.