### PR TITLE
Fix `getNimibVersion()`

### DIFF
--- a/src/nimib/config.nim
+++ b/src/nimib/config.nim
@@ -1,11 +1,12 @@
 import types, parsetoml, jsony, std / [json, os, osproc, math, sequtils]
 
 proc getNimibVersion*(): string = 
-  let 
-    # nimib/src/nimib/config.nim -> nimib/src/nimib/ -> nimib/src/ -> nimib/
+  var dir = currentSourcePath().parentDir().parentDir()
 
-    # please, an easier way to do this...
-    dumpedJson = execProcess("nimble dump --json", currentSourcePath().parentDir().parentDir().parentDir()) 
+  if dir.splitPath().tail == "src":
+    dir = dir.parentDir()
+
+  let dumpedJson = execProcess("nimble dump --json", dir) 
 
   result = parseJson(dumpedJson)["version"].getStr()
 

--- a/tests/tnimib.nim
+++ b/tests/tnimib.nim
@@ -1,4 +1,5 @@
 import std / [unittest, strformat, strutils]
+import nimib/config
 import nimib
 
 nbInit # todo: add a test suite for nbInit
@@ -266,3 +267,8 @@ when moduleAvailable(karax/kbase):
       check "you = \"me\"" in nb.blocks[^1].context["transformedCode"].vString
       check nb.blocks[^2].code.startsWith("let you =")
       check nb.blocks[^2].output == "hi me\n"
+
+test "getNimibVersion()":
+  let version = getNimibVersion()
+
+  check version.count('.') == 2


### PR DESCRIPTION
Forgot that nimble doesn't include the `src` dir, so you'd have to only call `parentDir` twice. 