### PR TITLE
Refactor tests and remove hints to better visualize success/failure

### DIFF
--- a/docsrc/numerical.nim
+++ b/docsrc/numerical.nim
@@ -18,7 +18,7 @@ proc introText(defaultStyle = false): string =
 > This nimib example document shows how to:
 >  - apply (or not) a custom style ([latex.css](https://latex.now.sh/)){otherStyle}
 >  - using latex rendering of equations (thanks to [katex](https://katex.org/))
->  - having as output an html table (using standard markdown converter to table) 
+>  - having as output an html table (using standard markdown converter to table)
 >
 > The document itself shows how to use [numericalnim](https://github.com/hugogranstrom/numericalnim)
 > to integrate an ODE.
@@ -53,22 +53,22 @@ We want to find the approximation to the solution and compare it with the analyt
 
 We will use two fixed timestep methods to find the solution:
   - Heun's 2nd order method (`Heun2`)
-  - classic 4th order Runge-Kutta (`RK4`) 
+  - classic 4th order Runge-Kutta (`RK4`)
 
 As timestamps we will use $h=0.1, 0.05, 0.01$.
 """
 nbText: "First we translate the ODE as $y'=f(y,t)$ with $f$:"
 nbCode:
-  proc f(t, y: float, ctx: NumContext[float]): float =
+  proc f(t, y: float, ctx: NumContext[float, float]): float =
     y - 0.5*exp(0.5*t)*sin(5*t) + 5*exp(0.5*t)*cos(5*t)
-  
+
   proc y(t: float): float =
     ## analytical solution
     exp(0.5*t)*sin(5*t)
-  
+
   let y0 = 0.0
   ## we will not be using the NumContext object
-  var ctx = newNumContext[float]()
+  var ctx = newNumContext[float, float]()
   ## first derivative that will be used
   echo "y'(0): ", f(0, y0, ctx)  # "$y'(0)$" will not be converted to latex (katex has a protection not to look into code)
   ## expected solution
@@ -140,5 +140,5 @@ nbSave
 # then save with default style
 blockIntroText.output = introText(default_style=true)
 nb.filename = filename_default_style
-nb.context["stylesheet"] = default_style 
+nb.context["stylesheet"] = default_style
 nbSave

--- a/docsrc/numerical.nim
+++ b/docsrc/numerical.nim
@@ -18,7 +18,7 @@ proc introText(defaultStyle = false): string =
 > This nimib example document shows how to:
 >  - apply (or not) a custom style ([latex.css](https://latex.now.sh/)){otherStyle}
 >  - using latex rendering of equations (thanks to [katex](https://katex.org/))
->  - having as output an html table (using standard markdown converter to table)
+>  - having as output an html table (using standard markdown converter to table) 
 >
 > The document itself shows how to use [numericalnim](https://github.com/hugogranstrom/numericalnim)
 > to integrate an ODE.
@@ -53,22 +53,22 @@ We want to find the approximation to the solution and compare it with the analyt
 
 We will use two fixed timestep methods to find the solution:
   - Heun's 2nd order method (`Heun2`)
-  - classic 4th order Runge-Kutta (`RK4`)
+  - classic 4th order Runge-Kutta (`RK4`) 
 
 As timestamps we will use $h=0.1, 0.05, 0.01$.
 """
 nbText: "First we translate the ODE as $y'=f(y,t)$ with $f$:"
 nbCode:
-  proc f(t, y: float, ctx: NumContext[float, float]): float =
+  proc f(t, y: float, ctx: NumContext[float]): float =
     y - 0.5*exp(0.5*t)*sin(5*t) + 5*exp(0.5*t)*cos(5*t)
-
+  
   proc y(t: float): float =
     ## analytical solution
     exp(0.5*t)*sin(5*t)
-
+  
   let y0 = 0.0
   ## we will not be using the NumContext object
-  var ctx = newNumContext[float, float]()
+  var ctx = newNumContext[float]()
   ## first derivative that will be used
   echo "y'(0): ", f(0, y0, ctx)  # "$y'(0)$" will not be converted to latex (katex has a protection not to look into code)
   ## expected solution
@@ -140,5 +140,5 @@ nbSave
 # then save with default style
 blockIntroText.output = introText(default_style=true)
 nb.filename = filename_default_style
-nb.context["stylesheet"] = default_style
+nb.context["stylesheet"] = default_style 
 nbSave

--- a/nimib.nimble
+++ b/nimib.nimble
@@ -28,10 +28,13 @@ task readme, "update readme":
   exec "nim -d:mdOutput r docsrc/index.nim"  
 
 task docs, "Build documentation":
-  for file in ["hello", "mostaccio", "numerical", "nolan",
+  # Requires numericalnim, datamancer, ggplotnim
+  for file in ["hello", "mostaccio", "nolan",
     "pythno", "cheatsheet", "files", "index",
     "interactivity", "counters", "caesar"]:
     exec "nim r --hints:off docsrc/" & file & ".nim"
+  # This fails due to an error in numericalnim
+  # exec "nim r --hints:off docsrc/numerical.nim" 
   when not defined(nimibDocsSkipPenguins):
     exec "nim r --hints:off docsrc/penguins.nim"
   exec "nimble readme"  

--- a/nimib.nimble
+++ b/nimib.nimble
@@ -28,13 +28,10 @@ task readme, "update readme":
   exec "nim -d:mdOutput r docsrc/index.nim"  
 
 task docs, "Build documentation":
-  # Requires numericalnim, datamancer, ggplotnim
-  for file in ["hello", "mostaccio", "nolan",
+  for file in ["hello", "mostaccio", "numerical", "nolan",
     "pythno", "cheatsheet", "files", "index",
     "interactivity", "counters", "caesar"]:
     exec "nim r --hints:off docsrc/" & file & ".nim"
-  # This fails due to an error in numericalnim
-  # exec "nim r --hints:off docsrc/numerical.nim" 
   when not defined(nimibDocsSkipPenguins):
     exec "nim r --hints:off docsrc/penguins.nim"
   exec "nimble readme"  

--- a/nimib.nimble
+++ b/nimib.nimble
@@ -19,13 +19,10 @@ task docsdeps, "install dependendencies required for doc building":
   exec "nimble -y install ggplotnim@0.5.3 numericalnim@0.6.1 nimoji nimpy karax@1.2.2"
 
 task test, "General tests":
-  exec "nim r tests/tsources.nim"
-  exec "nim r tests/tblocks.nim"
-  exec "nim r -d:nimibCodeFromAst tests/tblocks.nim"
-  exec "nim r tests/tnimib.nim"
-  exec "nim r -d:nimibCodeFromAst tests/tnimib.nim"
-  exec "nim r tests/trenders.nim"
-  exec "nim r -d:nimibCodeFromAst tests/trenders.nim"
+  for file in ["tsources.nim", "tblocks.nim", "tnimib.nim", "trenders.nim"]:
+    exec "nim r --hints:off tests/" & file
+  for file in ["tblocks.nim", "tnimib.nim", "trenders.nim"]:
+    exec "nim r --hints:off -d:nimibCodeFromAst tests/" & file
 
 task readme, "update readme":
   exec "nim -d:mdOutput r docsrc/index.nim"  

--- a/nimib.nimble
+++ b/nimib.nimble
@@ -28,17 +28,10 @@ task readme, "update readme":
   exec "nim -d:mdOutput r docsrc/index.nim"  
 
 task docs, "Build documentation":
-  exec "nim r docsrc/hello.nim"
-  exec "nim r docsrc/mostaccio.nim"
-  exec "nim r docsrc/numerical.nim"
-  exec "nim r docsrc/nolan.nim"
-  exec "nim r docsrc/pythno.nim"
-  exec "nim r docsrc/cheatsheet.nim"
-  exec "nim r docsrc/files.nim"
-  exec "nim r docsrc/index.nim"
-  exec "nim r docsrc/interactivity.nim"
-  exec "nim r docsrc/counters.nim"
-  exec "nim r docsrc/caesar.nim"
+  for file in ["hello", "mostaccio", "numerical", "nolan",
+    "pythno", "cheatsheet", "files", "index",
+    "interactivity", "counters", "caesar"]:
+    exec "nim r --hints:off docsrc/" & file & ".nim"
   when not defined(nimibDocsSkipPenguins):
-    exec "nim r docsrc/penguins.nim"
+    exec "nim r --hints:off docsrc/penguins.nim"
   exec "nimble readme"  


### PR DESCRIPTION
The for loop on the list of file names is more readable.
I added hints:off compilation option, to remove superfluous information for the tests. (Similarly to [bigints](https://github.com/nim-lang/bigints/blob/master/bigints.nimble))

To be consistent in syntax, I can do the same for documentation building.