### PR TITLE
Style code blocks

### DIFF
--- a/src/nimib/renders.nim
+++ b/src/nimib/renders.nim
@@ -20,6 +20,8 @@ proc useHtmlBackend*(doc: var NbDoc) =
   doc.partials["nbCapture"] = """{{>nbCodeOutput}}"""
   doc.partials["nbCodeSource"] = "<pre><code class=\"nohighlight hljs nim\">{{&codeHighlighted}}</code></pre>"
   doc.partials["nbCodeOutput"] = """{{#output}}<pre class="nb-output">{{output}}</pre>{{/output}}"""
+  doc.partials["nbCodeSource"] = "<pre class=\"nb-code\"><code class=\"nohighlight hljs nim nb-code\">{{&codeHighlighted}}</code></pre>"
+  doc.partials["nbCodeOutput"] = """{{#output}}<pre class="nb-output">{{output}}</pre>{{/output}}"""
   doc.partials["nimibCode"] = doc.partials["nbCode"]
   doc.partials["nbImage"] = """<figure>
 <img src="{{url}}" alt="{{alt_text}}">

--- a/src/nimib/themes.nim
+++ b/src/nimib/themes.nim
@@ -76,6 +76,23 @@ pre > code {
 }
 .nb-output {
   line-height: 1.15;
+  padding: 0.5rem;
+  margin-top: 0px;
+  border-color: #E8ECF0;
+  border-radius: 0px 0px 6px 6px;
+  border-width: 1px;
+  border-style: solid;
+  border-top-style: none;
+}
+.nb-code { 
+  background: #F3F6F8;
+  margin-bottom: 0px;
+  border-radius: 6px 6px 0px 0px;
+}
+pre.nb-code {
+  border-color: #E8ECF0;
+  border-width: 1px;
+  border-style: solid;
 }
 figure {
   margin: 2rem 0;


### PR DESCRIPTION
This is my attempt at implementing code blocks that look something like the DeepNote blocks in #65 . The styling still needs some tuning (feedback is welcome) and there are some things we might have to consider. For example the colors (the background color of the code and the border color), if I hardcode them as I do now, they will look bad in dark mode for example. Add to that all themes in [NimiTheme](https://github.com/neroist/nimitheme). If we hard-code them, it may look weird with any theme but the default light water.css theme. So we might have to go with using the default background color of the current theme. The border color could probably work if we set it to a grey-ish color, otherwise we get a fully black/white border which is not a good look.

@pietroppeter What is your opinion on this?