### PR TITLE
Fix std/random bug (#204)

### DIFF
--- a/nimib.nimble
+++ b/nimib.nimble
@@ -9,7 +9,7 @@ srcDir        = "src"
 # Dependencies
 
 requires "nim >= 1.4.0"
-requires "tempfile >= 0.1.6"
+requires "fusion >= 1.2"
 requires "markdown >= 0.8.1"
 requires "mustache >= 0.2.1"
 requires "parsetoml >= 0.7.0"

--- a/src/nimib/capture.nim
+++ b/src/nimib/capture.nim
@@ -3,17 +3,14 @@ import fusion/ioutils
 import std/os
 import std/tempfiles
 
-template captureStdout*(ident: untyped, body: untyped) =
-    captureStdout(ident, "", body)
-
 template captureStdout*(ident: untyped, filename: string, body: untyped) =
     ## redirect stdout to a temporary file and captures output of body in ident
     # Duplicate stdout
     let stdoutFileno: FileHandle = stdout.getFileHandle()
     let stdoutDupFd: FileHandle = stdoutFileno.duplicate()
     
-    # Create a new temporary file or attemp to open it
-    let (tmpFile, tmpFileName {.used.}) = when filename == "":
+    # Create a new temporary file or attempt to open it
+    let (tmpFile, tmpFileName {.used.}) = if filename == "":
             createTempFile("tmp", "")
         else:
             let tmpName = getTempDir() / filename
@@ -29,7 +26,7 @@ template captureStdout*(ident: untyped, filename: string, body: untyped) =
     # Flush stdout and tmpFile, read tmpFile from start to ident and then close tmpFile
     stdout.flushFile()
     tmpFile.flushFile()
-    when filename == "":
+    if filename == "":
         tmpFile.setFilePos(0)
     else:
         discard tmpFile.reopen(tmpFileName)
@@ -38,3 +35,6 @@ template captureStdout*(ident: untyped, filename: string, body: untyped) =
     
     # Restore stdout
     stdoutDupFd.duplicateTo(stdoutFileno)
+
+template captureStdout*(ident: untyped, body: untyped) =
+    captureStdout(ident, "", body)

--- a/src/nimib/capture.nim
+++ b/src/nimib/capture.nim
@@ -1,20 +1,15 @@
 ## This submodule implements only one template to temporarily redirect and capture stdout during execution of a chunk of code.
 import fusion/ioutils
-import std/os
 import std/tempfiles
 
-template captureStdout*(ident: untyped, filename: string, body: untyped) =
+template captureStdout*(ident: untyped, body: untyped) =
     ## redirect stdout to a temporary file and captures output of body in ident
     # Duplicate stdout
     let stdoutFileno: FileHandle = stdout.getFileHandle()
     let stdoutDupFd: FileHandle = stdoutFileno.duplicate()
     
     # Create a new temporary file or attempt to open it
-    let (tmpFile, tmpFileName {.used.}) = if filename == "":
-            createTempFile("tmp", "")
-        else:
-            let tmpName = getTempDir() / filename
-            (tmpName.open(fmAppend), tmpName)
+    let (tmpFile, _) = createTempFile("tmp", "")
     let tmpFileFd: FileHandle = tmpFile.getFileHandle() 
     
     # writing to stdoutFileno now writes to tmpFile
@@ -26,15 +21,9 @@ template captureStdout*(ident: untyped, filename: string, body: untyped) =
     # Flush stdout and tmpFile, read tmpFile from start to ident and then close tmpFile
     stdout.flushFile()
     tmpFile.flushFile()
-    if filename == "":
-        tmpFile.setFilePos(0)
-    else:
-        discard tmpFile.reopen(tmpFileName)
+    tmpFile.setFilePos(0)
     ident = tmpFile.readAll()
     tmpFile.close()
     
     # Restore stdout
     stdoutDupFd.duplicateTo(stdoutFileno)
-
-template captureStdout*(ident: untyped, body: untyped) =
-    captureStdout(ident, "", body)


### PR DESCRIPTION
- Remove OpenSystemsLab/tempfile.nim and replace with build-in `std/tempfiles`
Without `randomize()` that can be found in that package, the random result in user code will be consistent
- Remove low level stuff and replace with build-in `fusion/ioutils`
As it might break in newer Windows update
- Add ability to name the temp file
`reuse the same file every time` I don't know if this statement mean that you can give name the temp file and if it is already exist then open or temp file name is generate and you can use old file in some way, so I implement the first one. Should not break exist code (Didn't test against the main package)

This should not need to modify docs as it is internal stuff hide be hide `nbCode`
fixed #204

Test
```nim
import capture

var s: string

var msg = "hello"
echo msg & "1"
captureStdout(s):
    echo msg & "2"
    msg = "ciao"
echo msg & "3"

assert s == "hello2\n"

import random

echo rand(100) # result: 3
captureStdout(s, "my_random_tmp"):
    echo rand(100) # result: 89
    discard
# echo rand(100)
echo "s=", s

captureStdout(s, "my_random_tmp"):
    echo rand(100) # result: 18
echo "s=", s

captureStdout(s):
    echo "echo"
echo "s=", s
```
Expect result
```
hello1
ciao3
3
s= (lots of 89 and 18 depend on how many time you run)

s= (lots of 89 and 18 depend on how many time you run)

s=echo
```