### PR TITLE
Add nbFile overload for file embedding

### DIFF
--- a/docsrc/allblocks.nim
+++ b/docsrc/allblocks.nim
@@ -110,12 +110,21 @@ nimibCode:
 
 nbCodeBlock: "nbFile"
 nbText: """
-`nbFile` saves the content of the block into a file. It takes two arguments: the name of the file and the content of the file.
+`nbFile` can save the contents of block into a file or display the contents of a file. 
+
+To save to a file it takes two arguments: the name of the file and the content of the file.
 The content can be a string or a code block.
 """
 nimibCode:
   nbFile("exampleCode.nim"):
     echo "This code will be saved in the exampleCode.nim file."
+
+nbText: """
+
+To display a file, it takes one argument: the file's path.
+"""
+nimibCode:
+  nbFile("../LICENSE")
 
 nbCodeBlock: "nbRawHtml"
 nbText: """

--- a/src/nimib.nim
+++ b/src/nimib.nim
@@ -141,6 +141,13 @@ template nbFile*(name: string, body: untyped) =
     nb.blk.context["ext"] = name.getExt
     nb.blk.context["content"] = nb.blk.code
 
+template nbFile*(name: string) =
+  ## Render content of file instead of writing to it
+  newNbSlimBlock("nbFile"):
+    nb.blk.context["filename"] = name
+    nb.blk.context["ext"] = name.getExt
+    nb.blk.context["content"] = readFile(name)
+
 when moduleAvailable(nimpy):
   template nbInitPython*() =
     import nimpy

--- a/src/nimib.nim
+++ b/src/nimib.nim
@@ -142,7 +142,7 @@ template nbFile*(name: string, body: untyped) =
     nb.blk.context["content"] = nb.blk.code
 
 template nbFile*(name: string) =
-  ## Render content of file instead of writing to it
+  ## Read content from a file instead of writing to it
   newNbSlimBlock("nbFile"):
     nb.blk.context["filename"] = name
     nb.blk.context["ext"] = name.getExt


### PR DESCRIPTION
This also adds an example.

Note: On my machine locally it was impossible to fully run `nimble docs`, even after running `nimble docsDeps`.
Because it doesn't find the happyx custom block:
`/home/philipp/dev/nimib/docsrc/interactivity.nim(281, 5) Error: undeclared identifier: 'nbHappyxCode'`.

This is caused by the `when moduleAvailable(happyx)` check failing because
`/home/philipp/.nimble/pkgs2/happyx-3.0.0-09a3bb3a93ddca05b973235465eb1f2c6414d5b8/happyx/spa/tag.nim(216, 8) Error: undeclared identifier: 're2'`.

I assume that's a happyx problem.