### PR TITLE
Add: function to add line numbers to block. Not called yet.

### DIFF
--- a/src/nimib.nim
+++ b/src/nimib.nim
@@ -69,6 +69,12 @@ template nbInitMd*(thisFileRel = "") =
   if nb.options.filename == "":
     nb.filename = nb.filename.splitFile.name & ".md"
 
+template enableLineNumbersDoc* =
+  nb.context["enableLineNumber"] = true
+
+template enableLineNumbersBlock* =
+  nb.blk.context["enableLineNumber"] = true
+
 # block generation templates
 template newNbCodeBlock*(cmd: string, body, blockImpl: untyped) =
   newNbBlock(cmd, true, nb, nb.blk, body, blockImpl)
@@ -83,9 +89,21 @@ template nbCode*(body: untyped) =
     captureStdout(nb.blk.output):
       body
 
+proc addLineNumbersToHighlightedCode*(codeHl: string): string =
+  let nlines = codeHl.splitLines().len
+  var lineNumbers: seq[string] = @[] # newSeqOfCap(nlines)
+  for i in 1..nlines:
+    lineNumbers[i] = $i & "<br>"
+  result = """ <span class="hljs-comment">""" & lineNumbers.join("") & """</span>""" & codeHl
+
 template nbCodeSkip*(body: untyped) =
   newNbCodeBlock("nbCodeSkip", body):
     discard
+
+template nbCodeWithNumbers*(body: untyped) =
+  newNbCodeBlock("nbCode", body):
+    captureStdout(nb.blk.output):
+      body
 
 template nbCapture*(body: untyped) =
   newNbCodeBlock("nbCapture", body):

--- a/src/nimib/renders.nim
+++ b/src/nimib/renders.nim
@@ -11,6 +11,22 @@ proc highlightCode(doc: var NbDoc, blk: var NbBlock) =
   blk.context["codeHighlighted"] = highlightNim(blk.code)
 
 
+# assert addLineNumbersToHighlightedCode("""
+# func</span> decode(secret: openArray[<span class="hljs-built_in">int</span>]): <span class="hljs-built_in">string</span> =
+#   <span class="hljs-comment">## classified by NSA as &lt;strong&gt;TOP SECRET&lt;/strong&gt;</span>
+#   <span class="hljs-keyword">for</span> c <span class="hljs-keyword">in</span> secret:
+#     <span class="hljs-literal">result</span>.add <span class="hljs-built_in">char</span>(c)
+# """) == """
+# <span class="hljs-comment">1</span> func</span> decode(secret: openArray[<span class="hljs-built_in">int</span>]): <span class="hljs-built_in">string</span> =
+# <span class="hljs-comment">2</span>   <span class="hljs-comment">## classified by NSA as &lt;strong&gt;TOP SECRET&lt;/strong&gt;</span>
+# <span class="hljs-comment">3</span>   <span class="hljs-keyword">for</span> c <span class="hljs-keyword">in</span> secret:
+# <span class="hljs-comment">4</span>     <span class="hljs-literal">result</span>.add <span class="hljs-built_in">char</span>(c)
+# """
+
+proc addLineNumbers(doc: var NbDoc, blk: var NbBlock) =
+  if blk.context["enableLineNumbers"].castBool or doc.context["enableLineNumbers"].castBool:
+    blk.context["codeHighlighted"] = addLineNumbersToHIghlightedCode(blk.context["codeHighlighted"].castStr)
+
 proc useHtmlBackend*(doc: var NbDoc) =
   doc.partials["nbText"] = "{{&outputToHtml}}"
   doc.partials["nbCode"] = """


### PR DESCRIPTION
This PR is not finished yet. Attempt to fix #101.
to do:
- [ ] move tests to correct files
- [ ] addLineNumbersToHighlightedCode is not yet called
- [ ] Separate numbers from code in the generated HTML so that code can be copy-pasted without the numbers.

How can I call the newly added procedure `addLineNumbersToHighlightedCode`?
`AddLineNumbers` does nothing for the moment.