### PR TITLE
Add language field for full language highlighting on html backend

### DIFF
--- a/src/nimib/renders.nim
+++ b/src/nimib/renders.nim
@@ -125,6 +125,9 @@ proc render*(nb: var NbDoc, blk: var NbBlock): string =
     blk.context.searchTable(nb.partials)
     debugRender "partial " & nb.partials[blk.command]
     result = nb.partials[blk.command].render(blk.context)
+    if blk.language.len > 0:
+      result = result.replace("nohighlight hljs nim", "hljs " & blk.language)
+
 
 proc render*(nb: var NbDoc): string =
   var blocks: seq[string]

--- a/src/nimib/types.nim
+++ b/src/nimib/types.nim
@@ -7,6 +7,7 @@ type
     command*: string
     code*: string
     output*: string
+    language*: string
     context*: Context
   NbOptions* = object
     skipCfg*: bool


### PR DESCRIPTION
This simply adds a method for having highlight work on user defined languages, the same process likely should be done on the markdown side wherever possible. No clue the scale of the hackiness.