### PR TITLE
paths.nim: Fix import for FreeBSD

### DIFF
--- a/src/nimib/paths.nim
+++ b/src/nimib/paths.nim
@@ -1,4 +1,7 @@
-import "$nim/compiler/pathutils"
+when defined(FreeBSD):
+  import "$nim/lib/compiler/pathutils"
+else:
+  import "$nim/compiler/pathutils"
 export pathutils
 import os, strutils, hashes
 


### PR DESCRIPTION
`compiler` doesn't seem to be standard.
At least, in FreeBSD, it's in ${LOCALBASE}/nim/lib/compiler where ${LOCALBASE} is /usr/local by default.

Add a when defined to import `pathutils` on FreeBSD.