### PR TITLE
Make tests less noisy + edit `getNimibVersion` a bit

### DIFF
--- a/src/nimib/blocks.nim
+++ b/src/nimib/blocks.nim
@@ -17,7 +17,7 @@ func nbNormalize*(text: string): string =
 # note that: '\c' == '\r' and '\l' == '\n'
 
 template newNbBlock*(cmd: string, readCode: static[bool], nbDoc, nbBlock, body, blockImpl: untyped) =
-  # stdout.write "[nimib] ", nbDoc.blocks.len, " ", cmd, ": "
+  stdout.write "[nimib] ", nbDoc.blocks.len, " ", cmd, ": "
   nbBlock = NbBlock(command: cmd, context: newContext(searchDirs = @[], partials = nbDoc.partials))
   when readCode:
     nbBlock.code = nbNormalize:
@@ -25,9 +25,9 @@ template newNbBlock*(cmd: string, readCode: static[bool], nbDoc, nbBlock, body, 
         toStr(body)
       else:
         getCodeAsInSource(nbDoc.source, cmd, body)
-  # echo peekFirstLineOf(nbBlock.code)
+  echo peekFirstLineOf(nbBlock.code)
   blockImpl
-  # if len(nbBlock.output) > 0: echo "     -> ", peekFirstLineOf(nbBlock.output)
+  if len(nbBlock.output) > 0: echo "     -> ", peekFirstLineOf(nbBlock.output)
   nbBlock.context["code"] = nbBlock.code
   nbBlock.context["output"] = nbBlock.output.dup(removeSuffix)
   nbDoc.blocks.add nbBlock

--- a/src/nimib/blocks.nim
+++ b/src/nimib/blocks.nim
@@ -17,7 +17,7 @@ func nbNormalize*(text: string): string =
 # note that: '\c' == '\r' and '\l' == '\n'
 
 template newNbBlock*(cmd: string, readCode: static[bool], nbDoc, nbBlock, body, blockImpl: untyped) =
-  stdout.write "[nimib] ", nbDoc.blocks.len, " ", cmd, ": "
+  # stdout.write "[nimib] ", nbDoc.blocks.len, " ", cmd, ": "
   nbBlock = NbBlock(command: cmd, context: newContext(searchDirs = @[], partials = nbDoc.partials))
   when readCode:
     nbBlock.code = nbNormalize:
@@ -25,9 +25,9 @@ template newNbBlock*(cmd: string, readCode: static[bool], nbDoc, nbBlock, body, 
         toStr(body)
       else:
         getCodeAsInSource(nbDoc.source, cmd, body)
-  echo peekFirstLineOf(nbBlock.code)
+  # echo peekFirstLineOf(nbBlock.code)
   blockImpl
-  if len(nbBlock.output) > 0: echo "     -> ", peekFirstLineOf(nbBlock.output)
+  # if len(nbBlock.output) > 0: echo "     -> ", peekFirstLineOf(nbBlock.output)
   nbBlock.context["code"] = nbBlock.code
   nbBlock.context["output"] = nbBlock.output.dup(removeSuffix)
   nbDoc.blocks.add nbBlock

--- a/src/nimib/config.nim
+++ b/src/nimib/config.nim
@@ -6,7 +6,8 @@ proc getNimibVersion*(): string =
   if dir.splitPath().tail == "src":
     dir = dir.parentDir()
 
-  let dumpedJson = execProcess("nimble dump --silent --json", dir) 
+  let dumpedJson = execProcess("nimble", args=["dump", "--silent", "--json"], 
+                                       workingDir=dir, options={poUsePath}) 
 
   result = parseJson(dumpedJson)["version"].getStr()
 

--- a/src/nimib/jsutils.nim
+++ b/src/nimib/jsutils.nim
@@ -164,7 +164,7 @@ macro nbHappyxCodeBackend*(rootId: untyped, args: varargs[untyped]) =
     preRoutesCode.add(i)
 
   let imports = quote do:
-    import happyx, std/ strformat
+    import happyx, std / strformat
 
   let newBody = quote do:
     `imports`

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -2,5 +2,4 @@ switch("path", "$projectDir/../src")
 switch("define", "nimibNoLog")
 
 switch("warning", "UnusedImport:off")
-switch("warning", "Spacing:off")
 switch("warning", "Deprecated:off")

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -1,1 +1,6 @@
 switch("path", "$projectDir/../src")
+switch("define", "nimibNoLog")
+
+switch("warning", "UnusedImport:off")
+switch("warning", "Spacing:off")
+switch("warning", "Deprecated:off")

--- a/tests/tblocks.nim
+++ b/tests/tblocks.nim
@@ -25,4 +25,6 @@ suite "newNbBlock":
       let b = 3.21
     check blk.code == ""
 
+    fail()
+
 

--- a/tests/tnimib.nim
+++ b/tests/tnimib.nim
@@ -268,7 +268,8 @@ when moduleAvailable(karax/kbase):
       check nb.blocks[^2].code.startsWith("let you =")
       check nb.blocks[^2].output == "hi me\n"
 
-test "getNimibVersion()":
-  let version = getNimibVersion()
+suite "test nimib/config":
+  test "getNimibVersion()":
+    let version = getNimibVersion()
 
-  check version.count('.') == 2
+    check version.count('.') == 2


### PR DESCRIPTION
The commits explain the changes made -- the purpose for this PR is to make `nimble test` less noisy with less Nim compiler & Nimib printing to stdout. This PR also depends on #242 with `switch("define", "nimibNoLog")`, but that line can be easily removed if needed.

`getNimibVersion()` is changed as I wanted it to use the `args` parameter similar to the other invocations of `execProcess()`.