### PR TITLE
Update Nimib conference presentation links (add 2024, fix 2021) - and NimibLand migration node

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ you should be reading one of the two, for the other:
 Nimib was presented at [NimConf2022](https://nim-lang.org/nimconf2022/), see the [slides](https://github.com/pietroppeter/nimconf22-nimib/) and click thumbnail to see video.
 [![nimib nimconf2022 thumbnail](https://github.com/pietroppeter/nimib/raw/d4399747aa4c4435d27e0038046ad0311a92f21d/assets/nimib-nimconf-thumbnail.png)](https://www.youtube.com/watch?v=hZ7wX1kgnuc)
 
-Nimib was also presented in [NimConf2021](https://conf.nim-lang.org),
+Nimib was also presented in [NimConf2021](https://conf.nim-lang.org/2021/),
 see [video](https://www.youtube.com/watch?v=sWA58Wtk6L8)
-and [slides](https://github.com/pietroppeter/nimconf2021).
+and [slides](https://github.com/pietroppeter/nimconf2021);
+and at [NimConf2024](https://conf.nim-lang.org/2024/), see [video](https://www.youtube.com/watch?v=yUb6Vjl2ovw&list=PLxLdEZg8DRwSkT93RIO-CoY-MxHOjYzs2&index=9)
+and [slides](https://github.com/nimib-land/nimconf24).
 
 The VS Codium / Code extension
 [nimiboost](https://marketplace.visualstudio.com/items?itemName=hugogranstrom.nimiboost) ([Open VSX](https://open-vsx.org/extension/hugogranstrom/nimiboost))

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ The VS Codium / Code extension
 [nimiboost](https://marketplace.visualstudio.com/items?itemName=hugogranstrom.nimiboost) ([Open VSX](https://open-vsx.org/extension/hugogranstrom/nimiboost))
 provides syntax highlighting of embedded languages in nimib documents (eg. markdown, python, html) and a preview window of nimib documents inside the editor.
 
+👷‍♀️ Nimib ecosystem is being (veeery slooooowly) migrated to [NimibLand](https://github.com/nimib-land) org. 🏗️ 🐢
+
+
 ## 👋 🌍 Example Usage
 
 First have a look at the following html document: [hello.html](https://pietroppeter.github.io/nimib/hello.html)


### PR DESCRIPTION
Updated conference presentation details for Nimib, adding link for NimConf2024 and fixing link for NimConf2021. I think NimConf 2022 presentation still deserves the main place with thumbnail.