### PR TITLE
fix: gensym in newNbBlock

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,15 @@ Notes for maintainers:
 - When we tag a new release, we should auto generate the release notes. It does not hurt if we add more context to the release notes (e.g. taking notable elements from PR discussion). We might also want to add a release discussion post.
 - finally, after a release, we update this changelog (and bump version) using the same wording from release notes: https://github.com/pietroppeter/nimib/releases
 
+## v0.4.1
+Fixed a bug in `newNbBlock` where `toHtml` blocks were gensym'd which made string interpolation break because the interpolated variable wasn't gensym'd in the template string:
+
+```nim
+toHtml:
+  let x`gensym123 = 1
+  &"{x}" # doesn't work!
+```
+
 ## v0.4.0
 
 Nimib v0.4.0 brings with it a complete rewrite of the blocks and rendering backend. We have moved on from mustache templates to use a more Nim-native style.

--- a/nimib.nimble
+++ b/nimib.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.4.0"
+version       = "0.4.1"
 author        = "Pietro Peterlongo & Hugo Granström"
 description   = "nimib 🐳 - nim 👑 driven ⛵ publishing ✍"
 license       = "MIT"

--- a/src/nimib/nimibSugars.nim
+++ b/src/nimib/nimibSugars.nim
@@ -54,6 +54,27 @@ macro generateBlockInitializer*(typeName: typed): untyped =
   let initializer = newProc(procName, procParams, procBody)
   return initializer
 
+proc cleanName(n: NimNode): string =
+  ## Strips a trailing `gensymNNN suffix.
+  result = n.strVal
+  let tick = result.find('`')
+  if tick >= 0:
+    result = result[0 ..< tick]
+
+proc stripGensym(n: NimNode): NimNode =
+  case n.kind
+  of nnkSym, nnkIdent:
+    result = ident(cleanName(n))
+  of nnkOpenSymChoice, nnkClosedSymChoice:
+    # Collapse to an Ident
+    result = ident(cleanName(n[0]))
+  of nnkEmpty, nnkNone, nnkLiterals:
+    result = n
+  else:
+    result = copyNimNode(n)
+    for child in n:
+      result.add stripGensym(child)
+
 macro newNbBlock*(typeName: untyped, body: untyped): untyped =
   # typeName is either `ident` or
   # Infix
@@ -95,7 +116,7 @@ macro newNbBlock*(typeName: untyped, body: untyped): untyped =
   for n in body:
     let (name, body) = n.parseCallStmt()
     if eqIdent(name, "toHtml"):
-      toHtmlBody = body
+      toHtmlBody = body.stripGensym
     else:
       fields.add (name, body)
 

--- a/tests/tblocks.nim
+++ b/tests/tblocks.nim
@@ -1,10 +1,20 @@
 import nimib
-import std / [unittest, strutils]
+import std / [unittest, strutils, strformat]
 
 newNbBlock(ReadCodeBlock):
   code: string
   toHtml:
     blk.code
+
+template iCreateGensyms() =
+  newNbBlock(NotGensymed):
+    foo: int
+    toHtml:
+      let x = blk.foo
+      &"x: {x}"
+
+iCreateGensyms()
+  
 
 suite "newNbBlock":
   nbInit

--- a/tests/trenders.nim
+++ b/tests/trenders.nim
@@ -10,12 +10,12 @@ suite "render (block), html default backend":
 
   test "nbCode without output":
     nbCode: discard
-    check nb.render(nb.blk).strip == """<pre><code class="nohighlight hljs nim"><span class="hljs-keyword">discard</span></code></pre>"""
+    check nb.render(nb.blk).strip == """<pre><code class="nohighlight nim hljs"><span class="hljs-keyword">discard</span></code></pre>"""
 
   test "nbCode with output":
     nbCode: echo "hi"
     check nb.render(nb.blk).strip == """
-<pre><code class="nohighlight hljs nim"><span class="hljs-keyword">echo</span> <span class="hljs-string">&quot;hi&quot;</span></code></pre>
+<pre><code class="nohighlight nim hljs"><span class="hljs-keyword">echo</span> <span class="hljs-string">&quot;hi&quot;</span></code></pre>
 <pre class="nb-output">hi
 </pre>"""
 


### PR DESCRIPTION
`newNbBlock` didn't handle gensym'd variables, so when you used string interpolation in `toHtml`, the variable was gensym'd but not the string interpolated variable. I fixed it by stripping the gensym part. This only occured if `newNbBlock` was called inside a template. 

```nim
toHtml:
  let x = 1
  &"{x}"
# was transformed into:
toHtml:
  let x`gensym123 = 1
  &"{x}" # doesn't match anymore
```